### PR TITLE
[Feature, KEY-35] Changed goal to reflect an amount of KEY expected to sell

### DIFF
--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -35,7 +35,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     // Amount of raised money in wei
     uint256 public weiRaised;
 
-    // Minimum cap expected to raise in wei
+    // Minimum tokens expected to sell
     uint256 public goal;
 
     // Total amount of tokens purchased, including pre-sale
@@ -99,7 +99,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
      * @param _foundationPool — what is this?
      * @param _foundersPool — what is this?
      * @param _legalExpensesWallet — what is this?
-     * @param _goal — Minimum cap expected to raise in wei.
+     * @param _goal — Minimum amount of tokens expected to sell.
      */
     function SelfKeyCrowdsale(
         uint64 _startTime,
@@ -169,24 +169,23 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
 
             // re-calculate the token amount to be allocated
             tokens = weiAmount.mul(presaleRate);
-
-            //  Presale_cap must not be exceeded
-            require(totalPurchased.add(tokens) <= PRESALE_CAP);
         }
 
         // Total sale cap must not be exceeded
         require(totalPurchased.add(tokens) <= SALE_CAP);
 
-        // Update state
-        weiRaised = weiRaised.add(weiAmount);
-        weiContributed[beneficiary] = weiContributed[beneficiary].add(weiAmount);
-        totalPurchased = totalPurchased.add(tokens);
+
 
         if (kycVerified[beneficiary]) {
             token.safeTransfer(beneficiary, tokens);
         } else {
             addLockedBalance(beneficiary, tokens);
         }
+
+        // Update state
+        weiRaised = weiRaised.add(weiAmount);
+        weiContributed[beneficiary] = weiContributed[beneficiary].add(weiAmount);
+        totalPurchased = totalPurchased.add(tokens);
 
         TokenPurchase(
             msg.sender,
@@ -285,7 +284,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
      * @dev If crowdsale is unsuccessful, participants can claim refunds
      */
     function goalReached() public constant returns (bool) {
-        return weiRaised >= goal;
+        return totalPurchased >= goal;
     }
 
     /**

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -10,7 +10,7 @@ module.exports = (deployer, network, accounts) => {
   const endTime = startTime + 604800 // One week after startTime
   const rate = 30000 // approximately $0.015 per KEY at 1 ETH = $450
   const presaleRate = 45000 // approximately $0.01 per KEY at 1 ETH = $450
-  const goal = 13200000000000000000000 // approx. $5,940,000 at 1 ETH = $450
+  const goal = 450000000000000000000000000 // approx. $5,940,000 in KEY
 
   let foundationPool
   let foundersPool

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -160,7 +160,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
   })
 
   context('Crowdsale whose goal hasn\'t been reached', () => {
-    const hugeGoal = 3333333333333333333333
+    const hugeGoal = 950000000000000000000000000
     const sendAmount = web3.toWei(3, 'ether')
 
     before(async () => {

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,6 +1,6 @@
 const rate = 20000 // approximately $0.015 per KEY
 const presaleRate = 30000 // approximately $0.01 per KEY
-const goal = 1 // minimum expected to raise in wei
+const goal = 1 // minimum expected to sell
 
 module.exports = {
   rate,


### PR DESCRIPTION
Goal was changed from an expected amount of wei to raise to an expected amount of tokens to sell, since we're not tracking the wei contributed amount for pre-sale participants.