### PR TITLE
[Feature, KEY-34] Added  method for updating the ETH/KEY exchange rate

### DIFF
--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -174,8 +174,6 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         // Total sale cap must not be exceeded
         require(totalPurchased.add(tokens) <= SALE_CAP);
 
-
-
         if (kycVerified[beneficiary]) {
             token.safeTransfer(beneficiary, tokens);
         } else {
@@ -194,6 +192,15 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
             tokens
         );
         forwardFunds(beneficiary);
+    }
+
+    /**
+     * @dev Updates the conversion (ETH/KEY) rate, as long as the public sale hasn't started
+     * @param newRate - Updated conversion rate
+     */
+    function setRate(uint256 newRate) public onlyOwner {
+        require(now < startTime);
+        rate = newRate;
     }
 
     /**

--- a/test/SelfKeyCrowdsale_presale_test.js
+++ b/test/SelfKeyCrowdsale_presale_test.js
@@ -84,6 +84,14 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
       gas: 999999
     }))
 
+    it('allows the updating of public sale conversion rate before sale starts', async () => {
+      const rate1 = await presaleCrowdsale.rate.call()
+      const newRate = 50000
+      await presaleCrowdsale.setRate(newRate)
+      const rate2 = await presaleCrowdsale.rate.call()
+      assert.equal(rate2, newRate)
+    })
+
     // now verify them.
     await presaleCrowdsale.verifyKYC(buyer)
     await presaleCrowdsale.sendTransaction({ from: buyer, value: sendAmount })

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -135,8 +135,13 @@ contract('SelfKeyCrowdsale', (accounts) => {
     context('contributions above maximum purchase cap', () => {
       const sendAmount = PURCHASE_MAX_CAP_WEI + SIGNIFICANT_AMOUNT
 
-      it('are not allowed', () =>
-        assertThrows(crowdsaleContract.sendTransaction({ from: buyer3, value: sendAmount })))
+      it('are not allowed', () => {
+        assertThrows(crowdsaleContract.sendTransaction({ from: buyer3, value: sendAmount }))
+      })
+    })
+
+    it("doesn't allow updating the sale conversion rate if sale has already started", () => {
+      assertThrows(crowdsaleContract.setRate(999999))
     })
 
     it('can finalize token sale', async () => {


### PR DESCRIPTION
ETH/KEY exchange is now manually updatable **until public sale starts**.