### PR TITLE
[Feature, KEY-37] Removed all public-presale references and code functionality

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,7 +9,6 @@ module.exports = (deployer, network, accounts) => {
   // const startTime = 1507939200 // 14 October 2017 @ 12:00am (UTC)
   const endTime = startTime + 604800 // One week after startTime
   const rate = 30000 // approximately $0.015 per KEY at 1 ETH = $450
-  const presaleRate = 45000 // approximately $0.01 per KEY at 1 ETH = $450
   const goal = 450000000000000000000000000 // approx. $5,940,000 in KEY
 
   let foundationPool
@@ -35,7 +34,6 @@ module.exports = (deployer, network, accounts) => {
     startTime,
     endTime,
     rate,
-    presaleRate,
     wallet,
     foundationPool,
     foundersPool,

--- a/test/SelfKeyCrowdsale_presale_test.js
+++ b/test/SelfKeyCrowdsale_presale_test.js
@@ -2,7 +2,7 @@ const SelfKeyCrowdsale = artifacts.require('./SelfKeyCrowdsale.sol')
 const SelfKeyToken = artifacts.require('./SelfKeyToken.sol')
 
 const assertThrows = require('./utils/assertThrows')
-const { rate, presaleRate, goal } = require('./utils/common')
+const { rate, goal } = require('./utils/common')
 
 contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
   const YEAR_IN_SECONDS = 31622400
@@ -27,7 +27,6 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
       start,
       end,
       rate,
-      presaleRate,
       wallet,
       foundationPool,
       foundersPool,
@@ -74,29 +73,18 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
     await assertThrows(presaleCrowdsale.releaseLock(buyer3))
   })
 
-  // Public pre-sale
-  it('receives ETH and allocate due tokens for kyc-verified addresses', async () => {
+  it('does not allow any contributions before start time', async () => {
     const sendAmount = web3.toWei(1, 'ether')
-    // Participant is not KYC verified yet
-    await assertThrows(presaleCrowdsale.sendTransaction({
-      from: buyer,
-      value: sendAmount,
-      gas: 999999
-    }))
-
-    it('allows the updating of public sale conversion rate before sale starts', async () => {
-      const rate1 = await presaleCrowdsale.rate.call()
-      const newRate = 50000
-      await presaleCrowdsale.setRate(newRate)
-      const rate2 = await presaleCrowdsale.rate.call()
-      assert.equal(rate2, newRate)
-    })
-
-    // now verify them.
     await presaleCrowdsale.verifyKYC(buyer)
-    await presaleCrowdsale.sendTransaction({ from: buyer, value: sendAmount })
-    const balance = await presaleToken.balanceOf.call(buyer)
-    assert.equal(Number(balance), presaleRate * sendAmount)
+    await assertThrows(presaleCrowdsale.sendTransaction({ from: buyer, value: sendAmount }))
+  })
+
+  it('allows the updating of public sale conversion rate before sale starts', async () => {
+    const rate1 = await presaleCrowdsale.rate.call()
+    const newRate = 50000
+    await presaleCrowdsale.setRate(newRate)
+    const rate2 = await presaleCrowdsale.rate.call()
+    assert.equal(rate2, newRate)
   })
 
   it('does not release the founders\' locked tokens too soon', async () => {
@@ -112,7 +100,6 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
       start,
       start,
       rate,
-      presaleRate,
       wallet,
       foundationPool,
       foundersPool,
@@ -126,7 +113,6 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
       start,
       end,
       0,
-      presaleRate,
       wallet,
       foundationPool,
       foundersPool,
@@ -140,7 +126,6 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
       start,
       end,
       rate,
-      presaleRate,
       0x0,
       foundationPool,
       foundersPool,

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -4,7 +4,7 @@ const TokenTimelock = artifacts.require('zeppelin-solidity/contracts/token/Token
 const KYCRefundVault = artifacts.require('./KYCRefundVault.sol')
 
 const assertThrows = require('./utils/assertThrows')
-const { rate, presaleRate, goal } = require('./utils/common')
+const { rate, goal } = require('./utils/common')
 
 contract('SelfKeyCrowdsale', (accounts) => {
   const now = (new Date()).getTime() / 1000
@@ -35,7 +35,6 @@ contract('SelfKeyCrowdsale', (accounts) => {
         start,
         end,
         rate,
-        presaleRate,
         wallet,
         foundationPool,
         foundersPool,
@@ -173,7 +172,6 @@ contract('SelfKeyCrowdsale', (accounts) => {
         start,
         end,
         rate,
-        presaleRate,
         wallet,
         foundationPool,
         foundersPool,
@@ -219,7 +217,6 @@ contract('SelfKeyCrowdsale', (accounts) => {
         start,
         end,
         rate,
-        presaleRate,
         wallet,
         foundationPool,
         foundersPool,
@@ -250,12 +247,9 @@ contract('SelfKeyCrowdsale', (accounts) => {
     })
 
     it('should allow finalization', async () => {
-      let weiRaised = await crowdsaleContract.weiRaised.call()
       await crowdsaleContract.finalize()
       let finalized = await crowdsaleContract.isFinalized.call()
       assert.isTrue(finalized)
-      let weiRaised2 = await crowdsaleContract.weiRaised.call()
-      assert.isBelow(weiRaised2, weiRaised)
     })
 
     it('does not allow finalize to be re-invoked', async () => {

--- a/test/SelfKey_test.js
+++ b/test/SelfKey_test.js
@@ -1,7 +1,7 @@
 const SelfKeyCrowdsale = artifacts.require('./SelfKeyCrowdsale.sol')
 const SelfKeyToken = artifacts.require('./SelfKeyToken.sol')
 
-const { rate, presaleRate, goal } = require('./utils/common')
+const { rate, goal } = require('./utils/common')
 
 contract('SelfKeyToken', (accounts) => {
   const now = (new Date()).getTime() / 1000
@@ -26,7 +26,6 @@ contract('SelfKeyToken', (accounts) => {
       start,
       end,
       rate,
-      presaleRate,
       wallet,
       foundationPool,
       foundersPool,

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,9 +1,7 @@
 const rate = 20000 // approximately $0.015 per KEY
-const presaleRate = 30000 // approximately $0.01 per KEY
 const goal = 1 // minimum expected to sell
 
 module.exports = {
   rate,
-  presaleRate,
   goal
 }


### PR DESCRIPTION
Pre-sale is already closed, therefore the contract will only provide functionality for the public sale (and before start_time, for manually settling all off-chain pre-sale purchases).

Thus, all code functionality regarding public pre-sale was removed.