### PR TITLE
[Feature, KEY-30] Timelock parameters were updated for founders allocation 

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -15,9 +15,6 @@ contract CrowdsaleConfig {
     // 33% of the total supply cap
     uint256 public constant SALE_CAP = 1980000000 * MIN_UNIT;
 
-    // 80% of the sale cap
-    uint256 public constant PRESALE_CAP = 1584000000 * MIN_UNIT;
-
     // approx. $100 in wei at 1 ETH = $450
     uint256 public constant PURCHASE_MIN_CAP_WEI = 222222222000000000;
 
@@ -27,9 +24,12 @@ contract CrowdsaleConfig {
     // approx 49.5%
     uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_UNIT;
 
+    // 16.5% Timelocked for a year
+    uint256 public constant FOUNDERS_TOKENS_VESTED = 660000000 * MIN_UNIT;
+
+    // 5.5% Not vested
+    uint256 public constant FOUNDERS_TOKENS = 330000000 * MIN_UNIT;
+
     // 1%
     uint256 public constant LEGAL_EXPENSES_TOKENS = 60000000 * MIN_UNIT;
-
-    // 16.5%
-    uint256 public constant FOUNDERS_TOKENS_VESTED = 990000000 * MIN_UNIT;
 }

--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -24,11 +24,14 @@ contract CrowdsaleConfig {
     // approx 49.5%
     uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_UNIT;
 
-    // 16.5% Timelocked for a year
-    uint256 public constant FOUNDERS_TOKENS_VESTED = 660000000 * MIN_UNIT;
-
     // 5.5% Not vested
     uint256 public constant FOUNDERS_TOKENS = 330000000 * MIN_UNIT;
+
+    // 5.5% Timelocked for half a year
+    uint256 public constant FOUNDERS_TOKENS_VESTED_1 = 330000000 * MIN_UNIT;
+
+    // 5.5% Timelocked for a year
+    uint256 public constant FOUNDERS_TOKENS_VESTED_2 = 330000000 * MIN_UNIT;
 
     // 1%
     uint256 public constant LEGAL_EXPENSES_TOKENS = 60000000 * MIN_UNIT;

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -58,8 +58,9 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     address public foundersPool;
     address public legalExpensesWallet;
 
-    // Token Timelock
-    TokenTimelock public timelockFounders;
+    // Token Timelocks
+    TokenTimelock public timelockFounders1;
+    TokenTimelock public timelockFounders2;
 
     // Vault to hold funds until crowdsale is finalized. Allows refunding.
     KYCRefundVault public vault;
@@ -126,15 +127,17 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         foundersPool = _foundersPool;
         legalExpensesWallet = _legalExpensesWallet;
 
-        // Set timelocks to 1 year after startTime
-        uint64 unlockAt = uint64(startTime + 31622400);
-        timelockFounders = new TokenTimelock(token, foundersPool, unlockAt);
-        //timelockFounders2 = new TokenTimelock(token, foundersPool, unlockAt2);
+        // Set timelockss to 6 months and a year after startTime, respectively
+        uint64 unlockAt1 = uint64(startTime + 15811200);
+        uint64 unlockAt2 = uint64(startTime + 31622400);
+        timelockFounders1 = new TokenTimelock(token, foundersPool, unlockAt1);
+        timelockFounders2 = new TokenTimelock(token, foundersPool, unlockAt2);
 
         // Genesis allocation of tokens
         token.safeTransfer(foundersPool, FOUNDERS_TOKENS);
         token.safeTransfer(foundationPool, FOUNDATION_POOL_TOKENS);
-        token.safeTransfer(timelockFounders, FOUNDERS_TOKENS_VESTED);
+        token.safeTransfer(timelockFounders1, FOUNDERS_TOKENS_VESTED_1);
+        token.safeTransfer(timelockFounders2, FOUNDERS_TOKENS_VESTED_2);
         token.safeTransfer(legalExpensesWallet, LEGAL_EXPENSES_TOKENS);
     }
 
@@ -287,8 +290,12 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     /**
      * @dev Release Founders' time-locked tokens
      */
-    function releaseLockFounders() public {
-        timelockFounders.release();
+    function releaseLockFounders1() public {
+        timelockFounders1.release();
+    }
+
+    function releaseLockFounders2() public {
+        timelockFounders2.release();
     }
 
     /**

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -129,8 +129,13 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         // Set timelocks to 1 year after startTime
         uint64 unlockAt = uint64(startTime + 31622400);
         timelockFounders = new TokenTimelock(token, foundersPool, unlockAt);
+        //timelockFounders2 = new TokenTimelock(token, foundersPool, unlockAt2);
 
-        distributeInitialFunds();
+        // Genesis allocation of tokens
+        token.safeTransfer(foundersPool, FOUNDERS_TOKENS);
+        token.safeTransfer(foundationPool, FOUNDATION_POOL_TOKENS);
+        token.safeTransfer(timelockFounders, FOUNDERS_TOKENS_VESTED);
+        token.safeTransfer(legalExpensesWallet, LEGAL_EXPENSES_TOKENS);
     }
 
     /**
@@ -394,15 +399,6 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
             beneficiary,
             tokens
         );
-    }
-
-    /**
-     * @dev Initial allocation of tokens
-     */
-    function distributeInitialFunds() internal {
-        token.safeTransfer(foundationPool, FOUNDATION_POOL_TOKENS);
-        token.safeTransfer(timelockFounders, FOUNDERS_TOKENS_VESTED);
-        token.safeTransfer(legalExpensesWallet, LEGAL_EXPENSES_TOKENS);
     }
 
     /**

--- a/test/SelfKeyCrowdsale_presale_test.js
+++ b/test/SelfKeyCrowdsale_presale_test.js
@@ -88,7 +88,7 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
   })
 
   it('does not release the founders\' locked tokens too soon', async () => {
-    await assertThrows(presaleCrowdsale.releaseLockFounders())
+    await assertThrows(presaleCrowdsale.releaseLockFounders1())
   })
 
   it('does not allow locked token releasing to an empty address', async () => {

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -26,7 +26,8 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
   let crowdsaleContract
   let tokenContract
-  let timelockFoundersContract
+  let timelockFounders1Contract
+  let timelockFounders2Contract
   let vaultContract
 
   context('Regular Crowdsale', () => {
@@ -43,8 +44,10 @@ contract('SelfKeyCrowdsale', (accounts) => {
       )
       const token = await crowdsaleContract.token.call()
       tokenContract = await SelfKeyToken.at(token)
-      const timelockFounders = await crowdsaleContract.timelockFounders.call()
-      timelockFoundersContract = await TokenTimelock.at(timelockFounders)
+      const timelockFounders1 = await crowdsaleContract.timelockFounders1.call()
+      const timelockFounders2 = await crowdsaleContract.timelockFounders2.call()
+      timelockFounders1Contract = await TokenTimelock.at(timelockFounders1)
+      timelockFounders2Contract = await TokenTimelock.at(timelockFounders2)
       const vaultAddress = await crowdsaleContract.vault.call()
       vaultContract = await KYCRefundVault.at(vaultAddress)
     })
@@ -57,7 +60,8 @@ contract('SelfKeyCrowdsale', (accounts) => {
     })
 
     it('created token timelocks', () => {
-      assert.isNotNull(timelockFoundersContract)
+      assert.isNotNull(timelockFounders1Contract)
+      assert.isNotNull(timelockFounders2Contract)
     })
 
     it('created the Refund Vault', () => {
@@ -68,7 +72,8 @@ contract('SelfKeyCrowdsale', (accounts) => {
       // Get expected token amounts from contract config
       const expectedFoundationTokens = await crowdsaleContract.FOUNDATION_POOL_TOKENS.call()
       const expectedLegalTokens = await crowdsaleContract.LEGAL_EXPENSES_TOKENS.call()
-      const expectedTimelockFoundersTokens = await crowdsaleContract.FOUNDERS_TOKENS_VESTED.call()
+      const expectedtimelockFounders1Tokens = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_1.call()
+      const expectedtimelockFounders2Tokens = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_2.call()
       const foundationBalance = await tokenContract.balanceOf.call(foundationPool)
       // Check foundation Pool tokens are allocated correctly
       assert.equal(foundationBalance, Number(expectedFoundationTokens))
@@ -76,12 +81,15 @@ contract('SelfKeyCrowdsale', (accounts) => {
       const legalBalance = await tokenContract.balanceOf.call(legalExpensesWallet)
       // Check legal expenses wallet tokens are allocated correctly
       assert.equal(legalBalance, Number(expectedLegalTokens))
-      // Get timelock instance address
-      const timelockFoundersAddress = await crowdsaleContract.timelockFounders.call()
-      // Get founders' timelock balance
-      const timelockFoundersBalance = await tokenContract.balanceOf.call(timelockFoundersAddress)
-      // Check timelockFounders tokens are allocated correctly
-      assert.equal(timelockFoundersBalance, Number(expectedTimelockFoundersTokens))
+      // Get timelock instances addresses
+      const timelockFounders1Address = await crowdsaleContract.timelockFounders1.call()
+      const timelockFounders2Address = await crowdsaleContract.timelockFounders2.call()
+      // Get founders' timelock balances
+      const timelockFounders1Balance = await tokenContract.balanceOf.call(timelockFounders1Address)
+      const timelockFounders2Balance = await tokenContract.balanceOf.call(timelockFounders2Address)
+      // Check timelockFounders1 tokens are allocated correctly
+      assert.equal(timelockFounders1Balance, Number(expectedtimelockFounders1Tokens))
+      assert.equal(timelockFounders2Balance, Number(expectedtimelockFounders2Tokens))
     })
 
     it('receives ETH to buy tokens that get transferred to another address', async () => {
@@ -180,8 +188,10 @@ contract('SelfKeyCrowdsale', (accounts) => {
       )
       const token = await crowdsaleContract.token.call()
       tokenContract = await SelfKeyToken.at(token)
-      const timelockFounders = await crowdsaleContract.timelockFounders.call()
-      timelockFoundersContract = await TokenTimelock.at(timelockFounders)
+      const timelockFounders1 = await crowdsaleContract.timelockFounders1.call()
+      const timelockFounders2 = await crowdsaleContract.timelockFounders2.call()
+      timelockFounders1Contract = await TokenTimelock.at(timelockFounders1)
+      timelockFounders2Contract = await TokenTimelock.at(timelockFounders2)
       const vaultAddress = await crowdsaleContract.vault.call()
       vaultContract = await KYCRefundVault.at(vaultAddress)
     })


### PR DESCRIPTION
New founders' pool token allocation is as follows:

- 1/3 (5.5% of total supply cap) is made immediately available
- 1/3 (5.5% of total supply cap) is time-vested for 6 months
- 1/3 (5.5% of total supply cap) is time-vested for 1 year