### PR TITLE
[Feature, KEY-32] ETH price is updatable until start date

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -6,33 +6,36 @@ pragma solidity ^0.4.18;
  * @dev Holds all constants for SelfKeyCrowdsale contract
 */
 contract CrowdsaleConfig {
-    uint256 private constant TOKEN_DECIMALS = 18;
-    uint256 private constant MIN_UNIT = 10 ** uint256(TOKEN_DECIMALS);
+    uint256 public constant TOKEN_DECIMALS = 18;
+    uint256 public constant MIN_TOKEN_UNIT = 10 ** uint256(TOKEN_DECIMALS);
 
     // Initial distribution amounts
-    uint256 public constant TOTAL_SUPPLY_CAP = 6000000000 * MIN_UNIT;
+    uint256 public constant TOTAL_SUPPLY_CAP = 6000000000 * MIN_TOKEN_UNIT;
 
     // 33% of the total supply cap
-    uint256 public constant SALE_CAP = 1980000000 * MIN_UNIT;
+    uint256 public constant SALE_CAP = 1980000000 * MIN_TOKEN_UNIT;
 
-    // approx. $100 in wei at 1 ETH = $450
-    uint256 public constant PURCHASE_MIN_CAP_WEI = 222222222000000000;
+    // Minimum cap per purchaser on public sale = $100
+    uint256 public constant PURCHASER_MIN_CAP_USD = 100;
 
-    // approx. $15,000 in wei, per contributor
-    uint256 public constant PURCHASE_MAX_CAP_WEI = 33333333333000000000;
+    // Maximum cap per purchaser on public sale = $5,000
+    uint256 public constant PURCHASER_MAX_CAP_USD = 5000;
 
     // approx 49.5%
-    uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_UNIT;
+    uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_TOKEN_UNIT;
 
     // 5.5% Not vested
-    uint256 public constant FOUNDERS_TOKENS = 330000000 * MIN_UNIT;
+    uint256 public constant FOUNDERS_TOKENS = 330000000 * MIN_TOKEN_UNIT;
 
     // 5.5% Timelocked for half a year
-    uint256 public constant FOUNDERS_TOKENS_VESTED_1 = 330000000 * MIN_UNIT;
+    uint256 public constant FOUNDERS_TOKENS_VESTED_1 = 330000000 * MIN_TOKEN_UNIT;
 
     // 5.5% Timelocked for a year
-    uint256 public constant FOUNDERS_TOKENS_VESTED_2 = 330000000 * MIN_UNIT;
+    uint256 public constant FOUNDERS_TOKENS_VESTED_2 = 330000000 * MIN_TOKEN_UNIT;
 
     // 1%
-    uint256 public constant LEGAL_EXPENSES_TOKENS = 60000000 * MIN_UNIT;
+    uint256 public constant LEGAL_EXPENSES_TOKENS = 60000000 * MIN_TOKEN_UNIT;
+
+    // KEY price in USD (thousandths)
+    uint256 public constant TOKEN_PRICE_THOUSANDTH = 15;  // $0.015 per KEY
 }

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -108,13 +108,11 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         address _foundationPool,
         address _foundersPool,
         address _legalExpensesWallet,
-        //uint256 _ethPrice,
         uint256 _goal
     ) public
     {
         require(_endTime > _startTime);
         require(_wallet != 0x0);
-        //require(_ethPrice > 0);
 
         token = new SelfKeyToken(TOTAL_SUPPLY_CAP);
         // mints all tokens and gives them to the crowdsale
@@ -127,7 +125,6 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         foundationPool = _foundationPool;
         foundersPool = _foundersPool;
         legalExpensesWallet = _legalExpensesWallet;
-        //ethPrice = _ethPrice;
         goal = _goal;
 
         vault = new KYCRefundVault(wallet);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -8,7 +8,6 @@ module.exports = (deployer, network, accounts) => {
   const startTime = now + 172800 // Two days after current time
   // const startTime = 1507939200 // 14 October 2017 @ 12:00am (UTC)
   const endTime = startTime + 604800 // One week after startTime
-  const ethPrice = 760
   const goal = 166666666000000000000000000 // approx. $2,500,000 in KEY
 
   let foundationPool
@@ -37,7 +36,6 @@ module.exports = (deployer, network, accounts) => {
     foundationPool,
     foundersPool,
     legalExpensesWallet,
-    //ethPrice,
     goal
   )
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -8,8 +8,8 @@ module.exports = (deployer, network, accounts) => {
   const startTime = now + 172800 // Two days after current time
   // const startTime = 1507939200 // 14 October 2017 @ 12:00am (UTC)
   const endTime = startTime + 604800 // One week after startTime
-  const rate = 30000 // approximately $0.015 per KEY at 1 ETH = $450
-  const goal = 450000000000000000000000000 // approx. $5,940,000 in KEY
+  const ethPrice = 760
+  const goal = 166666666000000000000000000 // approx. $2,500,000 in KEY
 
   let foundationPool
   let foundersPool
@@ -33,11 +33,11 @@ module.exports = (deployer, network, accounts) => {
     SelfKeyCrowdsale,
     startTime,
     endTime,
-    rate,
     wallet,
     foundationPool,
     foundersPool,
     legalExpensesWallet,
+    //ethPrice,
     goal
   )
 }

--- a/test/SelfKey_test.js
+++ b/test/SelfKey_test.js
@@ -1,7 +1,7 @@
 const SelfKeyCrowdsale = artifacts.require('./SelfKeyCrowdsale.sol')
 const SelfKeyToken = artifacts.require('./SelfKeyToken.sol')
 
-const { rate, goal } = require('./utils/common')
+const { goal } = require('./utils/common')
 
 contract('SelfKeyToken', (accounts) => {
   const now = (new Date()).getTime() / 1000
@@ -25,7 +25,6 @@ contract('SelfKeyToken', (accounts) => {
     crowdsaleContract = await SelfKeyCrowdsale.new(
       start,
       end,
-      rate,
       wallet,
       foundationPool,
       foundersPool,

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,7 +1,5 @@
-const rate = 20000 // approximately $0.015 per KEY
 const goal = 1 // minimum expected to sell
 
 module.exports = {
-  rate,
   goal
 }

--- a/truffle.js
+++ b/truffle.js
@@ -35,7 +35,7 @@ module.exports = {
       network_id: 3,
       provider: engine,
       from: addresses[0],
-      gas: 5000000
+      gas: 4700000
     }
   },
   solc: {


### PR DESCRIPTION
ETH price is updatable via the `setEthPrice` method until sale start date. Conversion rates and USD-defined caps for the public sale are calculated according to this ETH price.