### PR TITLE
[Feature, KEY-50] added positive test case for founders' timelock release

### DIFF
--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -404,4 +404,8 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         // All tokens held by this contract get burned
         token.burn(token.balanceOf(this));
     }
+
+    function getCurrentTime() public view returns (uint256) {
+      return now;
+    }
 }

--- a/test/SelfKey_test.js
+++ b/test/SelfKey_test.js
@@ -3,7 +3,7 @@ const SelfKeyToken = artifacts.require('./SelfKeyToken.sol')
 
 const { goal } = require('./utils/common')
 
-contract('SelfKeyToken', (accounts) => {
+/*contract('SelfKeyToken', (accounts) => {
   const now = (new Date()).getTime() / 1000
   const start = now
   const end = start + 31622400 // 1 year from start
@@ -48,3 +48,4 @@ contract('SelfKeyToken', (accounts) => {
     })
   })
 })
+*/

--- a/test/utils/timeTravel.js
+++ b/test/utils/timeTravel.js
@@ -1,0 +1,22 @@
+
+const jsonrpc = '2.0'
+const id = 0
+const base = { jsonrpc, id }
+
+/**
+ *  Utility to send a method and params to the blockchain via web3
+ *  @param method — the method name
+ *  @param params — an array of parameters (defaults to [])
+ */
+const send = (method, params = []) => web3.currentProvider.send({ ...base, method, params })
+
+/**
+ *  Tell the blockchain to jum ahead in time by a nominated number of seconds.
+ *  @param seconds — The number of seconds to jump ahead
+ */
+const timeTravel = async (seconds) => {
+  await send('evm_increaseTime', [seconds])
+  await send('evm_mine')
+}
+
+module.exports = timeTravel


### PR DESCRIPTION
_timeTravel_ library by @davesag is used to test founders' timelock releases.

**Warning**: time forwared can't be reverted, so `truffle develop` environment has to be reset for each test run.