### PR TITLE
[Feature, KEY-59] on crowdsale day 1 a different purchaser max cap applies

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -21,6 +21,9 @@ contract CrowdsaleConfig {
     // Maximum cap per purchaser on public sale = $18,000 in KEY (at $0.015)
     uint256 public constant PURCHASER_MAX_TOKEN_CAP = 1200000 * MIN_TOKEN_UNIT;
 
+    // Maximum cap per purchaser on first day of public sale = $3,000 in KEY (at $0.015)
+    uint256 public constant PURCHASER_MAX_TOKEN_CAP_DAY1 = 200000 * MIN_TOKEN_UNIT;
+
     // approx 49.5%
     uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_TOKEN_UNIT;
 

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -298,7 +298,13 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
 
         require(totalPurchased <= SALE_CAP);
         require(tokensPurchased[participant] >= PURCHASER_MIN_TOKEN_CAP);
-        require(tokensPurchased[participant] <= PURCHASER_MAX_TOKEN_CAP);
+
+        if(now < startTime + 86400) {
+            // if still during the first day of token sale, apply different max cap
+            require(tokensPurchased[participant] <= PURCHASER_MAX_TOKEN_CAP_DAY1);
+        } else {
+            require(tokensPurchased[participant] <= PURCHASER_MAX_TOKEN_CAP);
+        }
 
         if (kycVerified[participant]) {
             token.safeTransfer(participant, tokens);

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -299,7 +299,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         require(totalPurchased <= SALE_CAP);
         require(tokensPurchased[participant] >= PURCHASER_MIN_TOKEN_CAP);
 
-        if(now < startTime + 86400) {
+        if (now < startTime + 86400) {
             // if still during the first day of token sale, apply different max cap
             require(tokensPurchased[participant] <= PURCHASER_MAX_TOKEN_CAP_DAY1);
         } else {

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -15,7 +15,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
   const SIGNIFICANT_AMOUNT = 2048
 
-  const [buyer, buyer2, buyer3, buyer4, buyer5, buyer6, receiver] = accounts.slice(1)
+  const [buyer, buyer2, buyer3, buyer4, buyer5, receiver] = accounts.slice(1)
 
   let crowdsaleContract
   let tokenContract
@@ -210,7 +210,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
     it('does not allow contributions above $18000 per purchaser afterwards', async () => {
       timeTravel(86400)   // fast forward 1 day
 
-      //it does allow purchases > $3000 after day 1
+      // it does allow purchases > $3000 after day 1
       let maxTokenCap = await crowdsaleContract.PURCHASER_MAX_TOKEN_CAP_DAY1.call()
       let rate = await crowdsaleContract.rate.call()
       let maxWei = Number(maxTokenCap) / Number(rate)


### PR DESCRIPTION
Modified `buyTokens` method so that a different max cap per purchaser applies if purchase is made on day 1 of token sale.