### PR TITLE
[Feature, KEY-61] changed splitting for founders and added legal expenses vesting

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -27,26 +27,25 @@ contract CrowdsaleConfig {
     // approx 49.5%
     uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_TOKEN_UNIT;
 
-    // 5.5% Not vested
-    uint256 public constant FOUNDERS_TOKENS = 330000000 * MIN_TOKEN_UNIT;
+    // Founders' distribution. Total = 16.5%
+    uint256 public constant FOUNDERS1_TOKENS = 311111111 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDERS1_TOKENS_VESTED_1 = 311111111 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDERS1_TOKENS_VESTED_2 = 311111111 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDERS2_TOKENS_VESTED = 56666667 * MIN_TOKEN_UNIT;
 
-    // 5.5% Timelocked for half a year
-    uint256 public constant FOUNDERS_TOKENS_VESTED_1 = 330000000 * MIN_TOKEN_UNIT;
-
-    // 5.5% Timelocked for a year
-    uint256 public constant FOUNDERS_TOKENS_VESTED_2 = 330000000 * MIN_TOKEN_UNIT;
-
-    // 1%
-    uint256 public constant LEGAL_EXPENSES_TOKENS = 60000000 * MIN_TOKEN_UNIT;
+    // 1% for legal advisors
+    uint256 public constant LEGAL_EXPENSES_TOKENS = 30000000 * MIN_TOKEN_UNIT;
+    uint256 public constant LEGAL_EXPENSES_TOKENS_VESTED = 30000000 * MIN_TOKEN_UNIT;
 
     // KEY price in USD (thousandths)
     uint256 public constant TOKEN_PRICE_THOUSANDTH = 15;  // $0.015 per KEY
 
     // Contract wallet addresses for initial allocation
-    address public constant CROWDSALE_WALLET_ADDR = 0xd061bc63e751B0B878d36a45D97F8B9E08984674;
-    address public constant FOUNDATION_POOL_ADDR = 0x15EB4FB06db8827fb82eF6DB1039e9cf88be867b;
-    address public constant FOUNDERS_POOL_ADDR = 0x65a57dEa007Dc8767cB2E27357c58c4334092d09;
-    address public constant LEGAL_EXPENSES_ADDR = 0x2e24aD707BeCAf1911A54E779f5CEB331F1c57aC;
+    address public constant CROWDSALE_WALLET_ADDR = 0x411A83c2b938EBF256939CDB552f5D176E8d4009;
+    address public constant FOUNDATION_POOL_ADDR = 0xC719DB33389eA25F5e72C1338dADb1D46F34b06E;
+    address public constant FOUNDERS_POOL_ADDR_1 = 0x7ac25aAc6a1c082aEbA716e614b0F8d1E3727aFB;
+    address public constant FOUNDERS_POOL_ADDR_2 = 0xbC08f9AEEc5fE01d9512dC8D47D7C57721917529;
+    address public constant LEGAL_EXPENSES_ADDR = 0x68335F976E97C6c0362f697BB9e5a70f44FA33a8;
 
     // some pre-sale purchasers have their tokens half-vested for a period of 6 months
     uint64 public constant PRECOMMITMENT_VESTING_SECONDS = 15552000;

--- a/test/SelfKeyCrowdsale_presale_test.js
+++ b/test/SelfKeyCrowdsale_presale_test.js
@@ -88,13 +88,15 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
     // assert.equal(Number(vestedBalance2) - Number(vestedBalance1), allocation - (allocation / 2))
 
     // test failure on premature release of tokens
-    await assertThrows(presaleCrowdsale.releaseLock(buyer3))
+    await assertThrows(presaleCrowdsale.releaseLock(sender))
   })
 
   it('does not allow any contributions before start time', async () => {
+    const sender = buyer
+
     const sendAmount = web3.toWei(1, 'ether')
-    await presaleCrowdsale.verifyKYC(buyer)
-    await assertThrows(presaleCrowdsale.sendTransaction({ from: buyer, value: sendAmount }))
+    await presaleCrowdsale.verifyKYC(sender)
+    await assertThrows(presaleCrowdsale.sendTransaction({ from: sender, value: sendAmount }))
   })
 
   it('allows the updating of ETH price before sale starts', async () => {
@@ -114,9 +116,13 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
 
   it('does not allow to set an ETH price equal to zero or negative number', async () => {
     assertThrows(presaleCrowdsale.setEthPrice(0))
+    assertThrows(presaleCrowdsale.setEthPrice(-999))
   })
 
   it('does not release the founders\' locked tokens too soon', async () => {
-    await assertThrows(presaleCrowdsale.releaseLockFounders1())
+    await assertThrows(presaleCrowdsale.releaseFirstLockFounders1())
+    await assertThrows(presaleCrowdsale.releaseSecondLockFounders1())
+    await assertThrows(presaleCrowdsale.releaseLockFounders2())
+    await assertThrows(presaleCrowdsale.releaseLockLegalExpenses())
   })
 })

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -392,36 +392,33 @@ contract('SelfKeyCrowdsale', (accounts) => {
       const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
       const foundersPool2 = await crowdsaleContract.FOUNDERS_POOL_ADDR_2.call()
       const legalPool = await crowdsaleContract.LEGAL_EXPENSES_ADDR.call()
-      const founders1expected1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
-      const founders1expected2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
-      const founders2expected = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
+      const founder1expected1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
+      const founder1expected2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
+      const founder2expected = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
       const legalExpected = await crowdsaleContract.LEGAL_EXPENSES_TOKENS_VESTED.call()
 
       // forward time 6 months
       await timeTravel(sixMonths)
 
       // test first timelock release
-      const founders1Balance1 = await tokenContract.balanceOf(foundersPool)
+      const founder1Balance1 = await tokenContract.balanceOf(foundersPool)
       await crowdsaleContract.releaseFirstLockFounders1()
-      const founders1Balance2 = await tokenContract.balanceOf(foundersPool)
-      assert.equal(
-        Number(founders1Balance2), Number(founders1Balance1) + Number(founders1expected1))
+      const founder1Balance2 = await tokenContract.balanceOf(foundersPool)
+      assert.equal(Number(founder1Balance2), Number(founder1Balance1) + Number(founder1expected1))
 
       // forward time an additional 6 months
       await timeTravel(sixMonths)
 
       // test second timelock release
       await crowdsaleContract.releaseSecondLockFounders1()
-      const founders1Balance3 = await tokenContract.balanceOf(foundersPool)
-      assert.equal(
-        Number(founders1Balance3), Number(founders1Balance2) + Number(founders1expected2))
+      const founder1Balance3 = await tokenContract.balanceOf(foundersPool)
+      assert.equal(Number(founder1Balance3), Number(founder1Balance2) + Number(founder1expected2))
 
       // check for second founders' address release
-      const founders2Balance1 = await tokenContract.balanceOf(foundersPool2)
+      const founder2Balance1 = await tokenContract.balanceOf(foundersPool2)
       await crowdsaleContract.releaseLockFounders2()
-      const founders2Balance2 = await tokenContract.balanceOf(foundersPool2)
-      assert.equal(
-        Number(founders2Balance2), Number(founders2Balance1) + Number(founders2expected))
+      const founder2Balance2 = await tokenContract.balanceOf(foundersPool2)
+      assert.equal(Number(founder2Balance2), Number(founder2Balance1) + Number(founder2expected))
 
       // check for legal expenses vested release
       const legalBalance1 = await tokenContract.balanceOf(legalPool)

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -19,8 +19,10 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
   let crowdsaleContract
   let tokenContract
-  let timelockFounders1Contract
-  let timelockFounders2Contract
+  let founders1Timelock1
+  let founders1Timelock2
+  let founders2Timelock
+  let legalExpensesTimelock
   let vaultContract
 
   context('Crowdsale whose goal hasn\'t been reached', () => {
@@ -35,10 +37,16 @@ contract('SelfKeyCrowdsale', (accounts) => {
       )
       const token = await crowdsaleContract.token.call()
       tokenContract = await SelfKeyToken.at(token)
-      const timelockFounders1 = await crowdsaleContract.timelockFounders1.call()
-      const timelockFounders2 = await crowdsaleContract.timelockFounders2.call()
-      timelockFounders1Contract = await TokenTimelock.at(timelockFounders1)
-      timelockFounders2Contract = await TokenTimelock.at(timelockFounders2)
+      const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
+      const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
+      const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
+      const legalExpensesTimelockAddress = await crowdsaleContract.legalExpensesTimelock.call()
+
+      founders1Timelock1 = await TokenTimelock.at(founders1Timelock1Address)
+      founders1Timelock2 = await TokenTimelock.at(founders1Timelock2Address)
+      founders2Timelock = await TokenTimelock.at(founders2TimelockAddress)
+      legalExpensesTimelock = await TokenTimelock.at(legalExpensesTimelockAddress)
+
       const vaultAddress = await crowdsaleContract.vault.call()
       vaultContract = await RefundVault.at(vaultAddress)
     })
@@ -87,10 +95,17 @@ contract('SelfKeyCrowdsale', (accounts) => {
       )
       const token = await crowdsaleContract.token.call()
       tokenContract = await SelfKeyToken.at(token)
-      const timelockFounders1 = await crowdsaleContract.timelockFounders1.call()
-      const timelockFounders2 = await crowdsaleContract.timelockFounders2.call()
-      timelockFounders1Contract = await TokenTimelock.at(timelockFounders1)
-      timelockFounders2Contract = await TokenTimelock.at(timelockFounders2)
+
+      const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
+      const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
+      const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
+      const legalExpensesTimelockAddress = await crowdsaleContract.legalExpensesTimelock.call()
+
+      founders1Timelock1 = await TokenTimelock.at(founders1Timelock1Address)
+      founders1Timelock2 = await TokenTimelock.at(founders1Timelock2Address)
+      founders2Timelock = await TokenTimelock.at(founders2TimelockAddress)
+      legalExpensesTimelock = await TokenTimelock.at(legalExpensesTimelockAddress)
+
       const vaultAddress = await crowdsaleContract.vault.call()
       vaultContract = await RefundVault.at(vaultAddress)
     })
@@ -99,8 +114,10 @@ contract('SelfKeyCrowdsale', (accounts) => {
       assert.isNotNull(crowdsaleContract)
       assert.isNotNull(tokenContract)
       assert.isNotNull(vaultContract)
-      assert.isNotNull(timelockFounders1Contract)
-      assert.isNotNull(timelockFounders2Contract)
+      assert.isNotNull(founders1Timelock1)
+      assert.isNotNull(founders1Timelock2)
+      assert.isNotNull(founders2Timelock)
+      assert.isNotNull(legalExpensesTimelock)
 
       // check token contract owner is the crowdsale contract
       const owner = await tokenContract.owner.call()
@@ -111,32 +128,41 @@ contract('SelfKeyCrowdsale', (accounts) => {
       // Get allocation wallet addresses
       const foundationPool = await crowdsaleContract.FOUNDATION_POOL_ADDR.call()
       const legalExpensesWallet = await crowdsaleContract.LEGAL_EXPENSES_ADDR.call()
-      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR.call()
-      const timelockFounders1Address = await crowdsaleContract.timelockFounders1.call()
-      const timelockFounders2Address = await crowdsaleContract.timelockFounders2.call()
+      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
+      const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
+      const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
+      const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
+      const legalExpensesTimelockAddress = await crowdsaleContract.legalExpensesTimelock.call()
 
       // Get expected token amounts from contract config
       const expectedFoundationTokens = await crowdsaleContract.FOUNDATION_POOL_TOKENS.call()
       const expectedLegalTokens = await crowdsaleContract.LEGAL_EXPENSES_TOKENS.call()
-      const expectedFoundersTokens = await crowdsaleContract.FOUNDERS_TOKENS.call()
-      const expectedtimelockFounders1Tokens =
-        await crowdsaleContract.FOUNDERS_TOKENS_VESTED_1.call()
-      const expectedtimelockFounders2Tokens =
-        await crowdsaleContract.FOUNDERS_TOKENS_VESTED_2.call()
+      const expectedFoundersTokens = await crowdsaleContract.FOUNDERS1_TOKENS.call()
+
+      const expectedFounders1Vested1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
+      const expectedFounders1Vested2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
+      const expectedFounders2Vested = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
+      const expectedLegalVested = await crowdsaleContract.LEGAL_EXPENSES_TOKENS_VESTED.call()
 
       // Get actual balances
       const foundationBalance = await tokenContract.balanceOf.call(foundationPool)
       const legalBalance = await tokenContract.balanceOf.call(legalExpensesWallet)
       const foundersBalance = await tokenContract.balanceOf.call(foundersPool)
-      const timelockFounders1Balance = await tokenContract.balanceOf.call(timelockFounders1Address)
-      const timelockFounders2Balance = await tokenContract.balanceOf.call(timelockFounders2Address)
+
+      const founders1vested1Balance1 = await tokenContract.balanceOf.call(founders1Timelock1Address)
+      const founders1vestedBalance2 = await tokenContract.balanceOf.call(founders1Timelock2Address)
+      const founders2vestedBalance = await tokenContract.balanceOf.call(founders2TimelockAddress)
+      const legalVestedBalance = await tokenContract.balanceOf.call(legalExpensesTimelockAddress)
 
       // Check allocation was done as expected
       assert.equal(foundationBalance, Number(expectedFoundationTokens))
       assert.equal(legalBalance, Number(expectedLegalTokens))
       assert.equal(foundersBalance, Number(expectedFoundersTokens))
-      assert.equal(timelockFounders1Balance, Number(expectedtimelockFounders1Tokens))
-      assert.equal(timelockFounders2Balance, Number(expectedtimelockFounders2Tokens))
+
+      assert.equal(founders1vested1Balance1, Number(expectedFounders1Vested1))
+      assert.equal(founders1vestedBalance2, Number(expectedFounders1Vested2))
+      assert.equal(founders2vestedBalance, Number(expectedFounders2Vested))
+      assert.equal(legalVestedBalance, Number(expectedLegalVested))
     })
 
     it('allows KYC verification of participant address', async () => {
@@ -361,28 +387,47 @@ contract('SelfKeyCrowdsale', (accounts) => {
       assert.equal(receiverBalance2.minus(receiverBalance1), sendAmount)
     })
 
-    it('should allow the release of locked tokens for the founders', async () => {
+    it('should allow the release of locked tokens for founders and legal advisors', async () => {
       const sixMonths = 15552000
-      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR.call()
-      const expectedRelease1 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_1.call()
-      const expectedRelease2 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_2.call()
+      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
+      const foundersPool2 = await crowdsaleContract.FOUNDERS_POOL_ADDR_2.call()
+      const legalPool = await crowdsaleContract.LEGAL_EXPENSES_ADDR.call()
+      const founders1expected1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
+      const founders1expected2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
+      const founders2expected = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
+      const legalExpected = await crowdsaleContract.LEGAL_EXPENSES_TOKENS_VESTED.call()
 
       // forward time 6 months
       await timeTravel(sixMonths)
 
       // test first timelock release
-      const foundersBalance1 = await tokenContract.balanceOf(foundersPool)
-      await crowdsaleContract.releaseLockFounders1()
-      const foundersBalance2 = await tokenContract.balanceOf(foundersPool)
-      assert.equal(Number(foundersBalance2), Number(foundersBalance1) + Number(expectedRelease1))
+      const founders1Balance1 = await tokenContract.balanceOf(foundersPool)
+      await crowdsaleContract.releaseFirstLockFounders1()
+      const founders1Balance2 = await tokenContract.balanceOf(foundersPool)
+      assert.equal(
+        Number(founders1Balance2), Number(founders1Balance1) + Number(founders1expected1))
 
       // forward time an additional 6 months
       await timeTravel(sixMonths)
 
       // test second timelock release
+      await crowdsaleContract.releaseSecondLockFounders1()
+      const founders1Balance3 = await tokenContract.balanceOf(foundersPool)
+      assert.equal(
+        Number(founders1Balance3), Number(founders1Balance2) + Number(founders1expected2))
+
+      // check for second founders' address release
+      const founders2Balance1 = await tokenContract.balanceOf(foundersPool2)
       await crowdsaleContract.releaseLockFounders2()
-      const foundersBalance3 = await tokenContract.balanceOf(foundersPool)
-      assert.equal(Number(foundersBalance3), Number(foundersBalance2) + Number(expectedRelease2))
+      const founders2Balance2 = await tokenContract.balanceOf(foundersPool2)
+      assert.equal(
+        Number(founders2Balance2), Number(founders2Balance1) + Number(founders2expected))
+
+      // check for legal expenses vested release
+      const legalBalance1 = await tokenContract.balanceOf(legalPool)
+      await crowdsaleContract.releaseLockLegalExpenses()
+      const legalBalance2 = await tokenContract.balanceOf(legalPool)
+      assert.equal(Number(legalBalance2), Number(legalBalance1) + Number(legalExpected))
     })
   })
 })

--- a/truffle.js
+++ b/truffle.js
@@ -35,7 +35,8 @@ module.exports = {
       network_id: 3,
       provider: engine,
       from: addresses[0],
-      gas: 4700000
+      gas: 4700000,
+      gasPrice: 100000000000
     }
   },
   solc: {


### PR DESCRIPTION
Added time-locked vesting of tokens for a second founders' address. Legal expenses is now 50% time-vested as well.