### PR TITLE
[Feature, KEY-62] Added splitting for legal expenses allocation

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -16,13 +16,13 @@ contract CrowdsaleConfig {
     uint256 public constant SALE_CAP = 1980000000 * MIN_TOKEN_UNIT;
 
     // Minimum cap per purchaser on public sale = $50 in KEY (at $0.015)
-    uint256 public constant PURCHASER_MIN_TOKEN_CAP = 3333 * MIN_TOKEN_UNIT;
-
-    // Maximum cap per purchaser on public sale = $18,000 in KEY (at $0.015)
-    uint256 public constant PURCHASER_MAX_TOKEN_CAP = 1200000 * MIN_TOKEN_UNIT;
+    uint256 public constant PURCHASER_MIN_TOKEN_CAP = 6666 * MIN_TOKEN_UNIT;
 
     // Maximum cap per purchaser on first day of public sale = $3,000 in KEY (at $0.015)
     uint256 public constant PURCHASER_MAX_TOKEN_CAP_DAY1 = 200000 * MIN_TOKEN_UNIT;
+
+    // Maximum cap per purchaser on public sale = $18,000 in KEY (at $0.015)
+    uint256 public constant PURCHASER_MAX_TOKEN_CAP = 1200000 * MIN_TOKEN_UNIT;
 
     // approx 49.5%
     uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_TOKEN_UNIT;
@@ -34,8 +34,9 @@ contract CrowdsaleConfig {
     uint256 public constant FOUNDERS2_TOKENS_VESTED = 56666667 * MIN_TOKEN_UNIT;
 
     // 1% for legal advisors
-    uint256 public constant LEGAL_EXPENSES_TOKENS = 30000000 * MIN_TOKEN_UNIT;
-    uint256 public constant LEGAL_EXPENSES_TOKENS_VESTED = 30000000 * MIN_TOKEN_UNIT;
+    uint256 public constant LEGAL_EXPENSES_1_TOKENS = 27000000 * MIN_TOKEN_UNIT;
+    uint256 public constant LEGAL_EXPENSES_1_TOKENS_VESTED = 27000000 * MIN_TOKEN_UNIT;
+    uint256 public constant LEGAL_EXPENSES_2_TOKENS = 6000000 * MIN_TOKEN_UNIT;
 
     // KEY price in USD (thousandths)
     uint256 public constant TOKEN_PRICE_THOUSANDTH = 15;  // $0.015 per KEY
@@ -45,7 +46,8 @@ contract CrowdsaleConfig {
     address public constant FOUNDATION_POOL_ADDR = 0xC719DB33389eA25F5e72C1338dADb1D46F34b06E;
     address public constant FOUNDERS_POOL_ADDR_1 = 0x7ac25aAc6a1c082aEbA716e614b0F8d1E3727aFB;
     address public constant FOUNDERS_POOL_ADDR_2 = 0xbC08f9AEEc5fE01d9512dC8D47D7C57721917529;
-    address public constant LEGAL_EXPENSES_ADDR = 0x68335F976E97C6c0362f697BB9e5a70f44FA33a8;
+    address public constant LEGAL_EXPENSES_ADDR_1 = 0x68335F976E97C6c0362f697BB9e5a70f44FA33a8;
+    address public constant LEGAL_EXPENSES_ADDR_2 = 0x03bd20e5f5f81b75D9fc1f1D1f1634dfa309DfC4;
 
     // some pre-sale purchasers have their tokens half-vested for a period of 6 months
     uint64 public constant PRECOMMITMENT_VESTING_SECONDS = 15552000;

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -107,18 +107,19 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         founders1Timelock1 = new TokenTimelock(token, FOUNDERS_POOL_ADDR_1, sixMonthLock);
         founders1Timelock2 = new TokenTimelock(token, FOUNDERS_POOL_ADDR_1, yearLock);
         founders2Timelock = new TokenTimelock(token, FOUNDERS_POOL_ADDR_2, yearLock);
-        legalExpensesTimelock = new TokenTimelock(token, LEGAL_EXPENSES_ADDR, yearLock);
+        legalExpensesTimelock = new TokenTimelock(token, LEGAL_EXPENSES_ADDR_1, sixMonthLock);
 
         // Genesis allocation of tokens
         token.safeTransfer(FOUNDATION_POOL_ADDR, FOUNDATION_POOL_TOKENS);
         token.safeTransfer(FOUNDERS_POOL_ADDR_1, FOUNDERS1_TOKENS);
-        token.safeTransfer(LEGAL_EXPENSES_ADDR, LEGAL_EXPENSES_TOKENS);
+        token.safeTransfer(LEGAL_EXPENSES_ADDR_1, LEGAL_EXPENSES_1_TOKENS);
+        token.safeTransfer(LEGAL_EXPENSES_ADDR_2, LEGAL_EXPENSES_2_TOKENS);
 
         // Allocation of vested tokens
         token.safeTransfer(founders1Timelock1, FOUNDERS1_TOKENS_VESTED_1);
         token.safeTransfer(founders1Timelock2, FOUNDERS1_TOKENS_VESTED_1);
         token.safeTransfer(founders2Timelock, FOUNDERS2_TOKENS_VESTED);
-        token.safeTransfer(legalExpensesTimelock, LEGAL_EXPENSES_TOKENS_VESTED);
+        token.safeTransfer(legalExpensesTimelock, LEGAL_EXPENSES_1_TOKENS_VESTED);
     }
 
     /**

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -127,42 +127,46 @@ contract('SelfKeyCrowdsale', (accounts) => {
     it('distributed the initial token amounts correctly', async () => {
       // Get allocation wallet addresses
       const foundationPool = await crowdsaleContract.FOUNDATION_POOL_ADDR.call()
-      const legalExpensesWallet = await crowdsaleContract.LEGAL_EXPENSES_ADDR.call()
+      const legalExpenses1Address = await crowdsaleContract.LEGAL_EXPENSES_ADDR_1.call()
+      const legalExpenses2Address = await crowdsaleContract.LEGAL_EXPENSES_ADDR_2.call()
       const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
       const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
       const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
       const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
-      const legalExpensesTimelockAddress = await crowdsaleContract.legalExpensesTimelock.call()
+      const legalExpenses1TimelockAddress = await crowdsaleContract.legalExpensesTimelock.call()
 
       // Get expected token amounts from contract config
       const expectedFoundationTokens = await crowdsaleContract.FOUNDATION_POOL_TOKENS.call()
-      const expectedLegalTokens = await crowdsaleContract.LEGAL_EXPENSES_TOKENS.call()
+      const expectedLegal1Tokens = await crowdsaleContract.LEGAL_EXPENSES_1_TOKENS.call()
+      const expectedLegal2Tokens = await crowdsaleContract.LEGAL_EXPENSES_2_TOKENS.call()
       const expectedFoundersTokens = await crowdsaleContract.FOUNDERS1_TOKENS.call()
 
       const expectedFounders1Vested1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
       const expectedFounders1Vested2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
       const expectedFounders2Vested = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
-      const expectedLegalVested = await crowdsaleContract.LEGAL_EXPENSES_TOKENS_VESTED.call()
+      const expectedLegal1Vested = await crowdsaleContract.LEGAL_EXPENSES_1_TOKENS_VESTED.call()
 
       // Get actual balances
       const foundationBalance = await tokenContract.balanceOf.call(foundationPool)
-      const legalBalance = await tokenContract.balanceOf.call(legalExpensesWallet)
+      const legal1Balance = await tokenContract.balanceOf.call(legalExpenses1Address)
+      const legal2Balance = await tokenContract.balanceOf.call(legalExpenses2Address)
       const foundersBalance = await tokenContract.balanceOf.call(foundersPool)
 
       const founders1vested1Balance1 = await tokenContract.balanceOf.call(founders1Timelock1Address)
       const founders1vestedBalance2 = await tokenContract.balanceOf.call(founders1Timelock2Address)
       const founders2vestedBalance = await tokenContract.balanceOf.call(founders2TimelockAddress)
-      const legalVestedBalance = await tokenContract.balanceOf.call(legalExpensesTimelockAddress)
+      const legal1VestedBalance = await tokenContract.balanceOf.call(legalExpenses1TimelockAddress)
 
       // Check allocation was done as expected
-      assert.equal(foundationBalance, Number(expectedFoundationTokens))
-      assert.equal(legalBalance, Number(expectedLegalTokens))
-      assert.equal(foundersBalance, Number(expectedFoundersTokens))
+      assert.equal(Number(foundationBalance), Number(expectedFoundationTokens))
+      assert.equal(Number(legal1Balance), Number(expectedLegal1Tokens))
+      assert.equal(Number(legal2Balance), Number(expectedLegal2Tokens))
+      assert.equal(Number(foundersBalance), Number(expectedFoundersTokens))
 
-      assert.equal(founders1vested1Balance1, Number(expectedFounders1Vested1))
-      assert.equal(founders1vestedBalance2, Number(expectedFounders1Vested2))
-      assert.equal(founders2vestedBalance, Number(expectedFounders2Vested))
-      assert.equal(legalVestedBalance, Number(expectedLegalVested))
+      assert.equal(Number(founders1vested1Balance1), Number(expectedFounders1Vested1))
+      assert.equal(Number(founders1vestedBalance2), Number(expectedFounders1Vested2))
+      assert.equal(Number(founders2vestedBalance), Number(expectedFounders2Vested))
+      assert.equal(Number(legal1VestedBalance), Number(expectedLegal1Vested))
     })
 
     it('allows KYC verification of participant address', async () => {
@@ -391,11 +395,11 @@ contract('SelfKeyCrowdsale', (accounts) => {
       const sixMonths = 15552000
       const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
       const foundersPool2 = await crowdsaleContract.FOUNDERS_POOL_ADDR_2.call()
-      const legalPool = await crowdsaleContract.LEGAL_EXPENSES_ADDR.call()
+      const legalPool = await crowdsaleContract.LEGAL_EXPENSES_ADDR_1.call()
       const founder1expected1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
       const founder1expected2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
       const founder2expected = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
-      const legalExpected = await crowdsaleContract.LEGAL_EXPENSES_TOKENS_VESTED.call()
+      const legalExpected = await crowdsaleContract.LEGAL_EXPENSES_1_TOKENS_VESTED.call()
 
       // forward time 6 months
       await timeTravel(sixMonths)


### PR DESCRIPTION
Legal expenses token allocation is split between two addresses now, with one of them half-vested for 6 months.