### PR TITLE
[Feature, KEY-63] Added splitting between foundation and community

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -24,8 +24,11 @@ contract CrowdsaleConfig {
     // Maximum cap per purchaser on public sale = $18,000 in KEY (at $0.015)
     uint256 public constant PURCHASER_MAX_TOKEN_CAP = 1200000 * MIN_TOKEN_UNIT;
 
-    // approx 49.5%
-    uint256 public constant FOUNDATION_POOL_TOKENS = 2970000000 * MIN_TOKEN_UNIT;
+    // 16.5%
+    uint256 public constant FOUNDATION_POOL_TOKENS = 990000000 * MIN_TOKEN_UNIT;
+
+    // Approx 33%
+    uint256 public constant COMMUNITY_POOL_TOKENS = 1980000000 * MIN_TOKEN_UNIT;
 
     // Founders' distribution. Total = 16.5%
     uint256 public constant FOUNDERS1_TOKENS = 311111111 * MIN_TOKEN_UNIT;
@@ -44,6 +47,7 @@ contract CrowdsaleConfig {
     // Contract wallet addresses for initial allocation
     address public constant CROWDSALE_WALLET_ADDR = 0x411A83c2b938EBF256939CDB552f5D176E8d4009;
     address public constant FOUNDATION_POOL_ADDR = 0xC719DB33389eA25F5e72C1338dADb1D46F34b06E;
+    address public constant COMMUNITY_POOL_ADDR = 0xD96969247B51187da3bf6418B3ED39304ae2006c;
     address public constant FOUNDERS_POOL_ADDR_1 = 0x7ac25aAc6a1c082aEbA716e614b0F8d1E3727aFB;
     address public constant FOUNDERS_POOL_ADDR_2 = 0xbC08f9AEEc5fE01d9512dC8D47D7C57721917529;
     address public constant LEGAL_EXPENSES_ADDR_1 = 0x68335F976E97C6c0362f697BB9e5a70f44FA33a8;

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -111,6 +111,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
 
         // Genesis allocation of tokens
         token.safeTransfer(FOUNDATION_POOL_ADDR, FOUNDATION_POOL_TOKENS);
+        token.safeTransfer(COMMUNITY_POOL_ADDR, COMMUNITY_POOL_TOKENS);
         token.safeTransfer(FOUNDERS_POOL_ADDR_1, FOUNDERS1_TOKENS);
         token.safeTransfer(LEGAL_EXPENSES_ADDR_1, LEGAL_EXPENSES_1_TOKENS);
         token.safeTransfer(LEGAL_EXPENSES_ADDR_2, LEGAL_EXPENSES_2_TOKENS);

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -127,6 +127,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
     it('distributed the initial token amounts correctly', async () => {
       // Get allocation wallet addresses
       const foundationPool = await crowdsaleContract.FOUNDATION_POOL_ADDR.call()
+      const communityPool = await crowdsaleContract.COMMUNITY_POOL_ADDR.call()
       const legalExpenses1Address = await crowdsaleContract.LEGAL_EXPENSES_ADDR_1.call()
       const legalExpenses2Address = await crowdsaleContract.LEGAL_EXPENSES_ADDR_2.call()
       const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
@@ -137,6 +138,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
       // Get expected token amounts from contract config
       const expectedFoundationTokens = await crowdsaleContract.FOUNDATION_POOL_TOKENS.call()
+      const expectedCommunityTokens = await crowdsaleContract.COMMUNITY_POOL_TOKENS.call()
       const expectedLegal1Tokens = await crowdsaleContract.LEGAL_EXPENSES_1_TOKENS.call()
       const expectedLegal2Tokens = await crowdsaleContract.LEGAL_EXPENSES_2_TOKENS.call()
       const expectedFoundersTokens = await crowdsaleContract.FOUNDERS1_TOKENS.call()
@@ -148,6 +150,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
       // Get actual balances
       const foundationBalance = await tokenContract.balanceOf.call(foundationPool)
+      const communityBalance = await tokenContract.balanceOf.call(communityPool)
       const legal1Balance = await tokenContract.balanceOf.call(legalExpenses1Address)
       const legal2Balance = await tokenContract.balanceOf.call(legalExpenses2Address)
       const foundersBalance = await tokenContract.balanceOf.call(foundersPool)
@@ -159,6 +162,7 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
       // Check allocation was done as expected
       assert.equal(Number(foundationBalance), Number(expectedFoundationTokens))
+      assert.equal(Number(communityBalance), Number(expectedCommunityTokens))
       assert.equal(Number(legal1Balance), Number(expectedLegal1Tokens))
       assert.equal(Number(legal2Balance), Number(expectedLegal2Tokens))
       assert.equal(Number(foundersBalance), Number(expectedFoundersTokens))


### PR DESCRIPTION
Foundation and community pools were separated as two different addresses for initial distribution, with different allocation percentages according to latest terms.