### PR TITLE
[Feature, KEY-64] initial allocation was changed according to latest terms

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -37,8 +37,7 @@ contract CrowdsaleConfig {
     uint256 public constant FOUNDERS2_TOKENS_VESTED = 56666667 * MIN_TOKEN_UNIT;
 
     // 1% for legal advisors
-    uint256 public constant LEGAL_EXPENSES_1_TOKENS = 27000000 * MIN_TOKEN_UNIT;
-    uint256 public constant LEGAL_EXPENSES_1_TOKENS_VESTED = 27000000 * MIN_TOKEN_UNIT;
+    uint256 public constant LEGAL_EXPENSES_1_TOKENS = 54000000 * MIN_TOKEN_UNIT;
     uint256 public constant LEGAL_EXPENSES_2_TOKENS = 6000000 * MIN_TOKEN_UNIT;
 
     // KEY price in USD (thousandths)

--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -25,16 +25,16 @@ contract CrowdsaleConfig {
     uint256 public constant PURCHASER_MAX_TOKEN_CAP = 1200000 * MIN_TOKEN_UNIT;
 
     // 16.5%
-    uint256 public constant FOUNDATION_POOL_TOKENS = 990000000 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDATION_POOL_TOKENS = 933333333 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDATION_POOL_TOKENS_VESTED = 56666667 * MIN_TOKEN_UNIT;
 
     // Approx 33%
     uint256 public constant COMMUNITY_POOL_TOKENS = 1980000000 * MIN_TOKEN_UNIT;
 
     // Founders' distribution. Total = 16.5%
-    uint256 public constant FOUNDERS1_TOKENS = 311111111 * MIN_TOKEN_UNIT;
-    uint256 public constant FOUNDERS1_TOKENS_VESTED_1 = 311111111 * MIN_TOKEN_UNIT;
-    uint256 public constant FOUNDERS1_TOKENS_VESTED_2 = 311111111 * MIN_TOKEN_UNIT;
-    uint256 public constant FOUNDERS2_TOKENS_VESTED = 56666667 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDERS_TOKENS = 330000000 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDERS_TOKENS_VESTED_1 = 330000000 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDERS_TOKENS_VESTED_2 = 330000000 * MIN_TOKEN_UNIT;
 
     // 1% for legal advisors
     uint256 public constant LEGAL_EXPENSES_1_TOKENS = 54000000 * MIN_TOKEN_UNIT;
@@ -47,11 +47,10 @@ contract CrowdsaleConfig {
     address public constant CROWDSALE_WALLET_ADDR = 0x411A83c2b938EBF256939CDB552f5D176E8d4009;
     address public constant FOUNDATION_POOL_ADDR = 0xC719DB33389eA25F5e72C1338dADb1D46F34b06E;
     address public constant COMMUNITY_POOL_ADDR = 0xD96969247B51187da3bf6418B3ED39304ae2006c;
-    address public constant FOUNDERS_POOL_ADDR_1 = 0x7ac25aAc6a1c082aEbA716e614b0F8d1E3727aFB;
-    address public constant FOUNDERS_POOL_ADDR_2 = 0xbC08f9AEEc5fE01d9512dC8D47D7C57721917529;
+    address public constant FOUNDERS_POOL_ADDR = 0x7ac25aAc6a1c082aEbA716e614b0F8d1E3727aFB;
     address public constant LEGAL_EXPENSES_ADDR_1 = 0x68335F976E97C6c0362f697BB9e5a70f44FA33a8;
     address public constant LEGAL_EXPENSES_ADDR_2 = 0x03bd20e5f5f81b75D9fc1f1D1f1634dfa309DfC4;
 
-    // some pre-sale purchasers have their tokens half-vested for a period of 6 months
+    // 6 months period, in seconds, for pre-commitment half-vesting
     uint64 public constant PRECOMMITMENT_VESTING_SECONDS = 15552000;
 }

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -48,9 +48,9 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     bool public isFinalized = false;
 
     // Token Timelocks
-    TokenTimelock public founders1Timelock1;
-    TokenTimelock public founders1Timelock2;
-    TokenTimelock public founders2Timelock;
+    TokenTimelock public foundersTimelock1;
+    TokenTimelock public foundersTimelock2;
+    TokenTimelock public foundationTimelock;
 
     // Vault to hold funds until crowdsale is finalized. Allows refunding if crowdsale is not successful.
     RefundVault public vault;
@@ -103,21 +103,21 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         uint64 yearLock = uint64(startTime + 31104000);
 
         // Instantiation of token timelocks
-        founders1Timelock1 = new TokenTimelock(token, FOUNDERS_POOL_ADDR_1, sixMonthLock);
-        founders1Timelock2 = new TokenTimelock(token, FOUNDERS_POOL_ADDR_1, yearLock);
-        founders2Timelock = new TokenTimelock(token, FOUNDERS_POOL_ADDR_2, yearLock);
+        foundersTimelock1 = new TokenTimelock(token, FOUNDERS_POOL_ADDR, sixMonthLock);
+        foundersTimelock2 = new TokenTimelock(token, FOUNDERS_POOL_ADDR, yearLock);
+        foundationTimelock = new TokenTimelock(token, FOUNDATION_POOL_ADDR, yearLock);
 
         // Genesis allocation of tokens
         token.safeTransfer(FOUNDATION_POOL_ADDR, FOUNDATION_POOL_TOKENS);
         token.safeTransfer(COMMUNITY_POOL_ADDR, COMMUNITY_POOL_TOKENS);
-        token.safeTransfer(FOUNDERS_POOL_ADDR_1, FOUNDERS1_TOKENS);
+        token.safeTransfer(FOUNDERS_POOL_ADDR, FOUNDERS_TOKENS);
         token.safeTransfer(LEGAL_EXPENSES_ADDR_1, LEGAL_EXPENSES_1_TOKENS);
         token.safeTransfer(LEGAL_EXPENSES_ADDR_2, LEGAL_EXPENSES_2_TOKENS);
 
         // Allocation of vested tokens
-        token.safeTransfer(founders1Timelock1, FOUNDERS1_TOKENS_VESTED_1);
-        token.safeTransfer(founders1Timelock2, FOUNDERS1_TOKENS_VESTED_1);
-        token.safeTransfer(founders2Timelock, FOUNDERS2_TOKENS_VESTED);
+        token.safeTransfer(foundersTimelock1, FOUNDERS_TOKENS_VESTED_1);
+        token.safeTransfer(foundersTimelock2, FOUNDERS_TOKENS_VESTED_2);
+        token.safeTransfer(foundationTimelock, FOUNDATION_POOL_TOKENS_VESTED);
     }
 
     /**
@@ -175,16 +175,16 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     /**
      * @dev Release time-locked tokens
      */
-    function releaseFirstLockFounders1() public {
-        founders1Timelock1.release();
-    }
-
-    function releaseSecondLockFounders1() public {
-        founders1Timelock2.release();
+    function releaseLockFounders1() public {
+        foundersTimelock1.release();
     }
 
     function releaseLockFounders2() public {
-        founders2Timelock.release();
+        foundersTimelock2.release();
+    }
+
+    function releaseLockFoundation() public {
+        foundationTimelock.release();
     }
 
     /**

--- a/test/SelfKeyCrowdsale_presale_test.js
+++ b/test/SelfKeyCrowdsale_presale_test.js
@@ -120,8 +120,8 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
   })
 
   it('does not release the founders\' locked tokens too soon', async () => {
-    await assertThrows(presaleCrowdsale.releaseFirstLockFounders1())
-    await assertThrows(presaleCrowdsale.releaseSecondLockFounders1())
+    await assertThrows(presaleCrowdsale.releaseLockFounders1())
     await assertThrows(presaleCrowdsale.releaseLockFounders2())
+    await assertThrows(presaleCrowdsale.releaseLockFoundation())
   })
 })

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -19,9 +19,9 @@ contract('SelfKeyCrowdsale', (accounts) => {
 
   let crowdsaleContract
   let tokenContract
-  let founders1Timelock1
-  let founders1Timelock2
-  let founders2Timelock
+  let foundersTimelock1
+  let foundersTimelock2
+  let foundationTimelock
   let vaultContract
 
   context('Crowdsale whose goal hasn\'t been reached', () => {
@@ -36,13 +36,13 @@ contract('SelfKeyCrowdsale', (accounts) => {
       )
       const token = await crowdsaleContract.token.call()
       tokenContract = await SelfKeyToken.at(token)
-      const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
-      const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
-      const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
+      const foundersTimelock1Address = await crowdsaleContract.foundersTimelock1.call()
+      const foundersTimelock2Address = await crowdsaleContract.foundersTimelock2.call()
+      const foundationTimelockAddress = await crowdsaleContract.foundationTimelock.call()
 
-      founders1Timelock1 = await TokenTimelock.at(founders1Timelock1Address)
-      founders1Timelock2 = await TokenTimelock.at(founders1Timelock2Address)
-      founders2Timelock = await TokenTimelock.at(founders2TimelockAddress)
+      foundersTimelock1 = await TokenTimelock.at(foundersTimelock1Address)
+      foundersTimelock2 = await TokenTimelock.at(foundersTimelock2Address)
+      foundationTimelock = await TokenTimelock.at(foundationTimelockAddress)
 
       const vaultAddress = await crowdsaleContract.vault.call()
       vaultContract = await RefundVault.at(vaultAddress)
@@ -93,13 +93,13 @@ contract('SelfKeyCrowdsale', (accounts) => {
       const token = await crowdsaleContract.token.call()
       tokenContract = await SelfKeyToken.at(token)
 
-      const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
-      const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
-      const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
+      const foundersTimelock1Address = await crowdsaleContract.foundersTimelock1.call()
+      const foundersTimelock2Address = await crowdsaleContract.foundersTimelock2.call()
+      const foundationTimelockAddress = await crowdsaleContract.foundationTimelock.call()
 
-      founders1Timelock1 = await TokenTimelock.at(founders1Timelock1Address)
-      founders1Timelock2 = await TokenTimelock.at(founders1Timelock2Address)
-      founders2Timelock = await TokenTimelock.at(founders2TimelockAddress)
+      foundersTimelock1 = await TokenTimelock.at(foundersTimelock1Address)
+      foundersTimelock2 = await TokenTimelock.at(foundersTimelock2Address)
+      foundationTimelock = await TokenTimelock.at(foundationTimelockAddress)
 
       const vaultAddress = await crowdsaleContract.vault.call()
       vaultContract = await RefundVault.at(vaultAddress)
@@ -109,9 +109,9 @@ contract('SelfKeyCrowdsale', (accounts) => {
       assert.isNotNull(crowdsaleContract)
       assert.isNotNull(tokenContract)
       assert.isNotNull(vaultContract)
-      assert.isNotNull(founders1Timelock1)
-      assert.isNotNull(founders1Timelock2)
-      assert.isNotNull(founders2Timelock)
+      assert.isNotNull(foundersTimelock1)
+      assert.isNotNull(foundersTimelock2)
+      assert.isNotNull(foundationTimelock)
 
       // check token contract owner is the crowdsale contract
       const owner = await tokenContract.owner.call()
@@ -124,21 +124,21 @@ contract('SelfKeyCrowdsale', (accounts) => {
       const communityPool = await crowdsaleContract.COMMUNITY_POOL_ADDR.call()
       const legalExpenses1Address = await crowdsaleContract.LEGAL_EXPENSES_ADDR_1.call()
       const legalExpenses2Address = await crowdsaleContract.LEGAL_EXPENSES_ADDR_2.call()
-      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
-      const founders1Timelock1Address = await crowdsaleContract.founders1Timelock1.call()
-      const founders1Timelock2Address = await crowdsaleContract.founders1Timelock2.call()
-      const founders2TimelockAddress = await crowdsaleContract.founders2Timelock.call()
+      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR.call()
+      const foundersTimelock1Address = await crowdsaleContract.foundersTimelock1.call()
+      const foundersTimelock2Address = await crowdsaleContract.foundersTimelock2.call()
+      const foundationTimelockAddress = await crowdsaleContract.foundationTimelock.call()
 
       // Get expected token amounts from contract config
       const expectedFoundationTokens = await crowdsaleContract.FOUNDATION_POOL_TOKENS.call()
       const expectedCommunityTokens = await crowdsaleContract.COMMUNITY_POOL_TOKENS.call()
       const expectedLegal1Tokens = await crowdsaleContract.LEGAL_EXPENSES_1_TOKENS.call()
       const expectedLegal2Tokens = await crowdsaleContract.LEGAL_EXPENSES_2_TOKENS.call()
-      const expectedFoundersTokens = await crowdsaleContract.FOUNDERS1_TOKENS.call()
+      const expectedFoundersTokens = await crowdsaleContract.FOUNDERS_TOKENS.call()
 
-      const expectedFounders1Vested1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
-      const expectedFounders1Vested2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
-      const expectedFounders2Vested = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
+      const expectedFoundersVested1 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_1.call()
+      const expectedFoundersVested2 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_2.call()
+      const expectedFoundationVested = await crowdsaleContract.FOUNDATION_POOL_TOKENS_VESTED.call()
 
       // Get actual balances
       const foundationBalance = await tokenContract.balanceOf.call(foundationPool)
@@ -147,9 +147,9 @@ contract('SelfKeyCrowdsale', (accounts) => {
       const legal2Balance = await tokenContract.balanceOf.call(legalExpenses2Address)
       const foundersBalance = await tokenContract.balanceOf.call(foundersPool)
 
-      const founders1vested1Balance1 = await tokenContract.balanceOf.call(founders1Timelock1Address)
-      const founders1vestedBalance2 = await tokenContract.balanceOf.call(founders1Timelock2Address)
-      const founders2vestedBalance = await tokenContract.balanceOf.call(founders2TimelockAddress)
+      const foundersVestedBalance1 = await tokenContract.balanceOf.call(foundersTimelock1Address)
+      const foundersVestedBalance2 = await tokenContract.balanceOf.call(foundersTimelock2Address)
+      const foundationVestedBalance = await tokenContract.balanceOf.call(foundationTimelockAddress)
 
       // Check allocation was done as expected
       assert.equal(Number(foundationBalance), Number(expectedFoundationTokens))
@@ -158,9 +158,9 @@ contract('SelfKeyCrowdsale', (accounts) => {
       assert.equal(Number(legal2Balance), Number(expectedLegal2Tokens))
       assert.equal(Number(foundersBalance), Number(expectedFoundersTokens))
 
-      assert.equal(Number(founders1vested1Balance1), Number(expectedFounders1Vested1))
-      assert.equal(Number(founders1vestedBalance2), Number(expectedFounders1Vested2))
-      assert.equal(Number(founders2vestedBalance), Number(expectedFounders2Vested))
+      assert.equal(Number(foundersVestedBalance1), Number(expectedFoundersVested1))
+      assert.equal(Number(foundersVestedBalance2), Number(expectedFoundersVested2))
+      assert.equal(Number(foundationVestedBalance), Number(expectedFoundationVested))
     })
 
     it('allows KYC verification of participant address', async () => {
@@ -385,36 +385,40 @@ contract('SelfKeyCrowdsale', (accounts) => {
       assert.equal(receiverBalance2.minus(receiverBalance1), sendAmount)
     })
 
-    it('should allow the release of locked tokens for founders and legal advisors', async () => {
+    it('should allow the release of locked tokens for founders and foundation', async () => {
       const sixMonths = 15552000
-      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR_1.call()
-      const foundersPool2 = await crowdsaleContract.FOUNDERS_POOL_ADDR_2.call()
-      const founder1expected1 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_1.call()
-      const founder1expected2 = await crowdsaleContract.FOUNDERS1_TOKENS_VESTED_2.call()
-      const founder2expected = await crowdsaleContract.FOUNDERS2_TOKENS_VESTED.call()
+      const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR.call()
+      const foundationPool = await crowdsaleContract.FOUNDATION_POOL_ADDR.call()
+      const foundersExpected1 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_1.call()
+      const foundersExpected2 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_2.call()
+      const foundationExpected = await crowdsaleContract.FOUNDATION_POOL_TOKENS_VESTED.call()
 
       // forward time 6 months
       await timeTravel(sixMonths)
 
       // test first timelock release
-      const founder1Balance1 = await tokenContract.balanceOf(foundersPool)
-      await crowdsaleContract.releaseFirstLockFounders1()
-      const founder1Balance2 = await tokenContract.balanceOf(foundersPool)
-      assert.equal(Number(founder1Balance2), Number(founder1Balance1) + Number(founder1expected1))
+      const foundersBalance1 = await tokenContract.balanceOf(foundersPool)
+      await crowdsaleContract.releaseLockFounders1()
+      const foundersBalance2 = await tokenContract.balanceOf(foundersPool)
+      assert.equal(Number(foundersBalance2), Number(foundersBalance1) + Number(foundersExpected1))
+
+      // pre-commitment half-vested locks can be tested here as well
 
       // forward time an additional 6 months
       await timeTravel(sixMonths)
 
       // test second timelock release
-      await crowdsaleContract.releaseSecondLockFounders1()
-      const founder1Balance3 = await tokenContract.balanceOf(foundersPool)
-      assert.equal(Number(founder1Balance3), Number(founder1Balance2) + Number(founder1expected2))
-
-      // check for second founders' address release
-      const founder2Balance1 = await tokenContract.balanceOf(foundersPool2)
       await crowdsaleContract.releaseLockFounders2()
-      const founder2Balance2 = await tokenContract.balanceOf(foundersPool2)
-      assert.equal(Number(founder2Balance2), Number(founder2Balance1) + Number(founder2expected))
+      const foundersBalance3 = await tokenContract.balanceOf(foundersPool)
+      assert.equal(Number(foundersBalance3), Number(foundersBalance2) + Number(foundersExpected2))
+
+      // check for second foundation vested release
+      const foundationBalance1 = await tokenContract.balanceOf(foundationPool)
+      await crowdsaleContract.releaseLockFoundation()
+      const foundationBalance2 = await tokenContract.balanceOf(foundationPool)
+      assert.equal(
+        Number(foundationBalance2),
+        Number(foundationBalance1) + Number(foundationExpected))  // function-paren-newline
     })
   })
 })


### PR DESCRIPTION
Founders' second pool address was substituted by time-vested allocations for the foundation pool.