### PR TITLE
[Release, 1.1.3] Final release of SelfKey crowdsale and token

### DIFF
--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -46,6 +46,7 @@ contract CrowdsaleConfig {
     // Contract wallet addresses for initial allocation
     address public constant CROWDSALE_WALLET_ADDR = 0xE0831b1687c9faD3447a517F9371E66672505dB0;
     address public constant FOUNDATION_POOL_ADDR = 0xD68947892Ef4D94Cdef7165b109Cf6Cd3f58A8e8;
+    address public constant FOUNDATION_POOL_ADDR_VEST = 0xd0C24Bb82e71A44eA770e84A3c79979F9233308D;
     address public constant COMMUNITY_POOL_ADDR = 0x0506c5485AE54aB14C598Ef16C459409E5d8Fc03;
     address public constant FOUNDERS_POOL_ADDR = 0x4452d6454e777743a5Ee233fbe873055008fF528;
     address public constant LEGAL_EXPENSES_ADDR_1 = 0xb57911380F13A0a9a6Ba6562248674B5f56D7BFE;

--- a/contracts/CrowdsaleConfig.sol
+++ b/contracts/CrowdsaleConfig.sol
@@ -25,8 +25,8 @@ contract CrowdsaleConfig {
     uint256 public constant PURCHASER_MAX_TOKEN_CAP = 1200000 * MIN_TOKEN_UNIT;
 
     // 16.5%
-    uint256 public constant FOUNDATION_POOL_TOKENS = 933333333 * MIN_TOKEN_UNIT;
-    uint256 public constant FOUNDATION_POOL_TOKENS_VESTED = 56666667 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDATION_POOL_TOKENS = 876666666 * MIN_TOKEN_UNIT;
+    uint256 public constant FOUNDATION_POOL_TOKENS_VESTED = 113333334 * MIN_TOKEN_UNIT;
 
     // Approx 33%
     uint256 public constant COMMUNITY_POOL_TOKENS = 1980000000 * MIN_TOKEN_UNIT;

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -116,7 +116,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
         // Instantiation of token timelocks
         foundersTimelock1 = new TokenTimelock(token, FOUNDERS_POOL_ADDR, sixMonthLock);
         foundersTimelock2 = new TokenTimelock(token, FOUNDERS_POOL_ADDR, yearLock);
-        foundationTimelock = new TokenTimelock(token, FOUNDATION_POOL_ADDR, yearLock);
+        foundationTimelock = new TokenTimelock(token, FOUNDATION_POOL_ADDR_VEST, yearLock);
 
         // Genesis allocation of tokens
         token.safeTransfer(FOUNDATION_POOL_ADDR, FOUNDATION_POOL_TOKENS);
@@ -156,7 +156,7 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     }
 
     /**
-     * @dev Sets a new start date
+     * @dev Sets a new start date as long as token hasn't started yet
      * @param _startTime - unix timestamp of the new start time
      */
     function setStartTime (uint64 _startTime) public onlyOwner {
@@ -168,8 +168,8 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     }
 
     /**
-     * @dev Sets a new end date
-     * @param _endTime - unix timestamp of the new start time
+     * @dev Sets a new end date as long as end date hasn't been reached
+     * @param _endTime - unix timestamp of the new end time
      */
     function setEndTime (uint64 _endTime) public onlyOwner {
         require(now < endTime);

--- a/contracts/SelfKeyCrowdsale.sol
+++ b/contracts/SelfKeyCrowdsale.sol
@@ -156,6 +156,30 @@ contract SelfKeyCrowdsale is Ownable, CrowdsaleConfig {
     }
 
     /**
+     * @dev Sets a new start date
+     * @param _startTime - unix timestamp of the new start time
+     */
+    function setStartTime (uint64 _startTime) public onlyOwner {
+        require(now < startTime);
+        require(_startTime > now);
+        require(_startTime < endTime);
+
+        startTime = _startTime;
+    }
+
+    /**
+     * @dev Sets a new end date
+     * @param _endTime - unix timestamp of the new start time
+     */
+    function setEndTime (uint64 _endTime) public onlyOwner {
+        require(now < endTime);
+        require(_endTime > now);
+        require(_endTime > startTime);
+
+        endTime = _endTime;
+    }
+
+    /**
      * @dev Updates the ETH/USD conversion rate as long as the public sale hasn't started
      * @param _ethPrice - Updated conversion rate
      */

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,8 +1,6 @@
 const SelfKeyCrowdsale = artifacts.require('./SelfKeyCrowdsale.sol')
 
 module.exports = (deployer) => {
-  // Test dates. Change to real dates before launch
-
   const startTime = 1515888000    // 14 Jan 2018 00:00:00 UTC
   const endTime = 1517443200      // 1 Feb 2018 00:00:00 UTC
   const goal = 166666666666666667000000000   // approx. $2,500,000 in KEY

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,8 +3,8 @@ const SelfKeyCrowdsale = artifacts.require('./SelfKeyCrowdsale.sol')
 module.exports = (deployer) => {
   // Test dates. Change to real dates before launch
 
-  const startTime = 1516406400    // 20 Jan 2018 00:00:00 UTC
-  const endTime = 1517961600      // 7 Feb 2018 00:00:00 UTC
+  const startTime = 1515888000    // 14 Jan 2018 00:00:00 UTC
+  const endTime = 1517443200      // 1 Feb 2018 00:00:00 UTC
   const goal = 166666666666666667000000000   // approx. $2,500,000 in KEY
 
   deployer.deploy(

--- a/test/SelfKeyCrowdsale_presale_test.js
+++ b/test/SelfKeyCrowdsale_presale_test.js
@@ -162,4 +162,15 @@ contract('SelfKeyCrowdsale (Pre-sale)', (accounts) => {
     await assertThrows(presaleCrowdsale.releaseLockFounders2())
     await assertThrows(presaleCrowdsale.releaseLockFoundation())
   })
+
+  it('can change the start date if sale has not started', async () => {
+    const additionalTime = 9
+    const beforeStart = await presaleCrowdsale.startTime.call()
+    await presaleCrowdsale.setStartTime(Number(beforeStart) + additionalTime)
+    const laterStart = await presaleCrowdsale.startTime.call()
+    assert.equal(Number(laterStart), Number(beforeStart) + additionalTime)
+
+    await assertThrows(presaleCrowdsale.setStartTime(now - 999))
+    await assertThrows(presaleCrowdsale.setStartTime(end + 1))
+  })
 })

--- a/truffle.js
+++ b/truffle.js
@@ -53,7 +53,7 @@ module.exports = {
       provider: engineMainnet,
       from: addresses[0],
       gas: 7000000,
-      gasPrice: 200000000000
+      gasPrice: 75000000000
     }
   },
   solc: {

--- a/truffle.js
+++ b/truffle.js
@@ -52,7 +52,7 @@ module.exports = {
       network_id: 1,
       provider: engineMainnet,
       from: addresses[0],
-      gas: 7000000,
+      gas: 5000000,
       gasPrice: 75000000000
     }
   },


### PR DESCRIPTION
version 1.1.3 was the final version deployed to the Ethereum network, successfully selling out within 11 minutes during public sale.