### PR TITLE
[Feature, KEY-77] Airdrop contract

### DIFF
--- a/contracts/SelfKeyAirdrop.sol
+++ b/contracts/SelfKeyAirdrop.sol
@@ -56,6 +56,16 @@ contract SelfKeyAirdrop is Ownable {
     }
 
     /**
+     * @dev Changes default airdrop amount
+     * @param amount - new amount to set as airdrop amount
+     */
+    function setAirdropAmount (uint256 amount) public onlyOwner {
+        require(amount > 0);
+
+        airdropAmount = amount;
+    }
+
+    /**
      * @dev Withdraws a certain amount of tokens to the contract owner
      * @param amount - amount of tokens for withdrawal
      */

--- a/contracts/SelfKeyAirdrop.sol
+++ b/contracts/SelfKeyAirdrop.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.4.18;
+
+import './SelfKeyToken.sol';
+import './SelfKeyCrowdsale.sol';
+
+import 'zeppelin-solidity/contracts/token/SafeERC20.sol';
+import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
+
+
+/**
+ * @title SelfKeyAirdrop
+ * @dev SelfKey SelfKey promotional airdropping mechanism
+ */
+contract SelfKeyAirdrop is Ownable {
+    using SafeERC20 for SelfKeyToken;
+
+    mapping(address => bool) public airdropped;
+    mapping(address => bool) public isAirdropper;
+
+    uint256 public airdropAmount = 10;
+
+    SelfKeyCrowdsale public crowdsale;
+    SelfKeyToken public token;
+
+    /**
+     * @dev restricts a method to be only callable by addresses whitelisted as "airdroppers"
+     */
+    modifier airdropperOnly() {
+        require(isAirdropper[msg.sender]);
+        _;
+    }
+
+    /**
+     * @dev SelfKeyAirdrop contract constructor
+     * @param crowdsaleAddress - address of the SelfKey crowdsale contract
+     */
+    function SelfKeyAirdrop (address crowdsaleAddress, address tokenAddress) public {
+        crowdsale = SelfKeyCrowdsale(crowdsaleAddress);
+        token = SelfKeyToken(tokenAddress);
+    }
+
+    /**
+     * @dev Adds an address to the whitelist of Airdroppers
+     * @param _address - address of the airdropper
+     */
+    function addAirdropper (address _address) public onlyOwner {
+        isAirdropper[_address] = true;
+    }
+
+    /**
+     * @dev Removes an address from the whitelist of Airdroppers
+     * @param _address - address of the airdropper to be removed
+     */
+    function removeAirdropper (address _address) public onlyOwner {
+        isAirdropper[_address] = false;
+    }
+
+    /**
+     * @dev Withdraws a certain amount of tokens to the contract owner
+     * @param amount - amount of tokens for withdrawal
+     */
+    function withdrawTokens (uint256 amount) public onlyOwner {
+        token.safeTransfer(owner, amount);
+    }
+
+    /**
+     * @dev Triggers 'airdrop' for a certain address.
+     *      It requires the address to be verifier previously for the SelfKey Crowdsale
+     * @param _to - address to whom the airdrop is being done
+     */
+    function airdrop (address _to) public airdropperOnly {
+        require(crowdsale.kycVerified(_to));
+        require(!airdropped[_to]);
+
+        airdropped[_to] = true;
+        token.safeTransfer(_to, airdropAmount);
+    }
+}

--- a/migrations/3_deploy_airdrop.js
+++ b/migrations/3_deploy_airdrop.js
@@ -1,0 +1,12 @@
+const SelfKeyAirdrop = artifacts.require('./SelfKeyAirdrop.sol')
+
+module.exports = (deployer) => {
+  const crowdsaleAddress = ''
+  const tokenAddress = ''
+
+  deployer.deploy(
+    SelfKeyAirdrop,
+    crowdsaleAddress,
+    tokenAddress
+  )
+}

--- a/test/SelfKeyAirdrop_tests.js
+++ b/test/SelfKeyAirdrop_tests.js
@@ -123,4 +123,15 @@ contract('Airdrop contract', (accounts) => {
     const withdrawAmount = 100
     await assertThrows(airdropContract.withdrawTokens(withdrawAmount, { from: notOwner }))
   })
+
+  it('allows setting a token amount by the owner', async () => {
+    const newAmount = 1000
+    await airdropContract.setAirdropAmount(newAmount)
+    const airdropAmount = await airdropContract.airdropAmount.call()
+    assert.equal(Number(airdropAmount), newAmount)
+  })
+
+  it('does not allow setting token amount by a non-owner', async () => {
+    await assertThrows(airdropContract.setAirdropAmount(900, { from: notOwner }))
+  })
 })

--- a/test/SelfKeyAirdrop_tests.js
+++ b/test/SelfKeyAirdrop_tests.js
@@ -1,0 +1,126 @@
+const SelfKeyCrowdsale = artifacts.require('./SelfKeyCrowdsale.sol')
+const SelfKeyToken = artifacts.require('./SelfKeyToken.sol')
+const SelfKeyAirdrop = artifacts.require('./SelfKeyAirdrop.sol')
+
+const assertThrows = require('./utils/assertThrows')
+const { goal } = require('./utils/common')
+
+contract('Airdrop contract', (accounts) => {
+  const YEAR_IN_SECONDS = 31622400
+  const now = (new Date()).getTime() / 1000
+  const start = now
+  const end = start + YEAR_IN_SECONDS
+  const goal = 1
+
+  const [buyer, buyer2, notVerified, airdropper, airdropper2, notOwner] = accounts.slice(3)
+
+  let crowdsaleContract
+  let airdropContract
+  let tokenContract
+
+  before(async () => {
+    // deploy crowdsale contract
+    crowdsaleContract = await SelfKeyCrowdsale.new(start, end, goal)
+
+    const tokenAddress = await crowdsaleContract.token.call()
+    tokenContract = await SelfKeyToken.at(tokenAddress)
+
+    // run small crowdsale
+    // verify buyer and let it make a purchase
+    let sendAmount = web3.toWei(2, 'ether')
+    await crowdsaleContract.verifyKYC(buyer)
+    await crowdsaleContract.verifyKYC(buyer2)
+    const isVerified = await crowdsaleContract.kycVerified.call(buyer)
+    const isVerified2 = await crowdsaleContract.kycVerified.call(buyer2)
+
+    assert.isTrue(isVerified)
+    assert.isTrue(isVerified2)
+
+    await crowdsaleContract.sendTransaction({ from: buyer, value: sendAmount })
+    await crowdsaleContract.sendTransaction({ from: buyer2, value: sendAmount })
+
+    // finalize crowdsale
+    await crowdsaleContract.finalize()
+    const finalized = await crowdsaleContract.isFinalized.call()
+    assert.isTrue(finalized)
+
+    // deploy airdrop contract
+    airdropContract = await SelfKeyAirdrop.new(crowdsaleContract.address, tokenContract.address)
+    //console.log("crowdsale address = " + crowdsaleContract.address)
+    //console.log("airdrop address = " + airdropContract.address)
+    assert.isNotNull(airdropContract)
+
+    // send tokens to the airdrop Contract
+    sendAmount = web3.toWei(1000, 'ether')
+    await tokenContract.transfer(airdropContract.address, sendAmount, { from: buyer2 })
+    const airdropBalance = await tokenContract.balanceOf.call(airdropContract.address)
+    assert.equal(Number(airdropBalance), sendAmount)
+  })
+
+  it('allows adding new airdropper', async () => {
+    // check it's not an airdropper yet
+    let isAirdropper = await airdropContract.isAirdropper.call(airdropper)
+    assert.isFalse(isAirdropper)
+
+    // add an airdropper
+    await airdropContract.addAirdropper(airdropper)
+    isAirdropper = await airdropContract.isAirdropper.call(airdropper)
+    assert.isTrue(isAirdropper)
+
+    // add another airdropper
+    await airdropContract.addAirdropper(airdropper2)
+    isAirdropper = await airdropContract.isAirdropper.call(airdropper2)
+    assert.isTrue(isAirdropper)
+  })
+
+  it('does not allow adding nor removing airdroppers by a non-owner', async () => {
+    await assertThrows(airdropContract.addAirdropper(buyer, { from: notOwner }))
+    await assertThrows(airdropContract.removeAirdropper(airdropper2, { from: notOwner }))
+  })
+
+  it('allows removing an airdropper', async () => {
+    // check address is an airdropper
+    let isAirdropper = await airdropContract.isAirdropper.call(airdropper2)
+    assert.isTrue(isAirdropper)
+
+    await airdropContract.removeAirdropper(airdropper2)
+    isAirdropper = await airdropContract.isAirdropper.call(airdropper2)
+    assert.isFalse(isAirdropper)
+  })
+
+  it('allows airdropping to a verified address', async () => {
+    const initialBuyerBalance = await tokenContract.balanceOf.call(buyer)
+    const initialAirdropBalance = await tokenContract.balanceOf.call(airdropContract.address)
+    const airdropAmount = await airdropContract.airdropAmount.call()
+    await airdropContract.airdrop(buyer, { from: airdropper })
+    const laterBuyerBalance = await tokenContract.balanceOf.call(buyer)
+    const laterAirdropBalance = await tokenContract.balanceOf.call(airdropContract.address)
+
+    assert.equal(Number(laterBuyerBalance), Number(initialBuyerBalance) + Number(airdropAmount))
+    assert.equal(Number(laterAirdropBalance), Number(initialAirdropBalance) - Number(airdropAmount))
+  })
+
+  it('does not allow airdropping more than once to the same address', async () => {
+    const airdropped = await airdropContract.airdropped.call(buyer)
+    assert.isTrue(airdropped)
+    await assertThrows(airdropContract.airdrop(buyer, { from: airdropper }))
+  })
+
+  it('does not allow airdropping to a non-verified address', async () => {
+    await assertThrows(airdropContract.airdrop(notVerified, { from: airdropper }))
+  })
+
+  it('allows withdrawal of tokens by the owner', async () => {
+    const withdrawAmount = 100
+    const initialOwnerBalance = await tokenContract.balanceOf(accounts[0])
+    await airdropContract.withdrawTokens(withdrawAmount)
+    const laterOwnerBalance = await tokenContract.balanceOf(accounts[0])
+
+    assert.equal(Number(laterOwnerBalance), Number(initialOwnerBalance) + withdrawAmount)
+  })
+
+  it('does not allow withdrawal of tokens by a non-owner', async () => {
+    const withdrawAmount = 100
+    await assertThrows(airdropContract.withdrawTokens(withdrawAmount, { from: notOwner }))
+  })
+})

--- a/test/SelfKeyAirdrop_tests.js
+++ b/test/SelfKeyAirdrop_tests.js
@@ -3,7 +3,6 @@ const SelfKeyToken = artifacts.require('./SelfKeyToken.sol')
 const SelfKeyAirdrop = artifacts.require('./SelfKeyAirdrop.sol')
 
 const assertThrows = require('./utils/assertThrows')
-const { goal } = require('./utils/common')
 
 contract('Airdrop contract', (accounts) => {
   const YEAR_IN_SECONDS = 31622400
@@ -46,8 +45,6 @@ contract('Airdrop contract', (accounts) => {
 
     // deploy airdrop contract
     airdropContract = await SelfKeyAirdrop.new(crowdsaleContract.address, tokenContract.address)
-    //console.log("crowdsale address = " + crowdsaleContract.address)
-    //console.log("airdrop address = " + airdropContract.address)
     assert.isNotNull(airdropContract)
 
     // send tokens to the airdrop Contract

--- a/test/SelfKeyCrowdsale_test.js
+++ b/test/SelfKeyCrowdsale_test.js
@@ -407,7 +407,6 @@ contract('SelfKeyCrowdsale', (accounts) => {
     it('should allow the release of locked tokens for founders and foundation', async () => {
       const sixMonths = 15552000
       const foundersPool = await crowdsaleContract.FOUNDERS_POOL_ADDR.call()
-      const foundationPool = await crowdsaleContract.FOUNDATION_POOL_ADDR.call()
       const foundersExpected1 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_1.call()
       const foundersExpected2 = await crowdsaleContract.FOUNDERS_TOKENS_VESTED_2.call()
       const vestedExpected = await crowdsaleContract.FOUNDATION_POOL_TOKENS_VESTED.call()


### PR DESCRIPTION
Added airdrop contract for giving away free tokens to addresses that were verified during the crowdsale.

Airdrop can only be triggered by whitelisted addresses added as "airdroppers". A single address cannot receive the airdrop more than once.