### PR TITLE
[Feature, KEY-84] Added airdrop counter and fixed default airdrop KEY amount

### DIFF
--- a/contracts/SelfKeyAirdrop.sol
+++ b/contracts/SelfKeyAirdrop.sol
@@ -17,7 +17,8 @@ contract SelfKeyAirdrop is Ownable {
     mapping(address => bool) public airdropped;
     mapping(address => bool) public isAirdropper;
 
-    uint256 public airdropAmount = 10;
+    uint256 public airdropAmount = 10000000000000000000;
+    uint256 public airdropCount = 0;
 
     SelfKeyCrowdsale public crowdsale;
     SelfKeyToken public token;
@@ -82,6 +83,7 @@ contract SelfKeyAirdrop is Ownable {
         require(crowdsale.kycVerified(_to));
         require(!airdropped[_to]);
 
+        airdropCount = airdropCount + 1;
         airdropped[_to] = true;
         token.safeTransfer(_to, airdropAmount);
     }

--- a/test/SelfKeyAirdrop_tests.js
+++ b/test/SelfKeyAirdrop_tests.js
@@ -89,12 +89,16 @@ contract('Airdrop contract', (accounts) => {
     const initialBuyerBalance = await tokenContract.balanceOf.call(buyer)
     const initialAirdropBalance = await tokenContract.balanceOf.call(airdropContract.address)
     const airdropAmount = await airdropContract.airdropAmount.call()
+    const airdropCount = await airdropContract.airdropCount.call()
     await airdropContract.airdrop(buyer, { from: airdropper })
     const laterBuyerBalance = await tokenContract.balanceOf.call(buyer)
     const laterAirdropBalance = await tokenContract.balanceOf.call(airdropContract.address)
+    const airdropCount2 = await airdropContract.airdropCount.call()
+
 
     assert.equal(Number(laterBuyerBalance), Number(initialBuyerBalance) + Number(airdropAmount))
     assert.equal(Number(laterAirdropBalance), Number(initialAirdropBalance) - Number(airdropAmount))
+    assert.equal(Number(airdropCount2), Number(airdropCount) + 1)
   })
 
   it('does not allow airdropping more than once to the same address', async () => {


### PR DESCRIPTION
An increasing counter was added to keep track of how many airdrops are performed. Additionally, the default airdrop amount was fixed to take into account decimal places (18). Default is set to `10000000000000000000` (10 KEY).