### PR TITLE
[Feature, KEY-106] Removed requirement for addresses to be whitelisted for airdrop

### DIFF
--- a/contracts/SelfKeyAirdrop.sol
+++ b/contracts/SelfKeyAirdrop.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.4.19;
 
 import './SelfKeyToken.sol';
-import './SelfKeyCrowdsale.sol';
 
 import 'zeppelin-solidity/contracts/token/ERC20/SafeERC20.sol';
 import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
@@ -20,7 +19,6 @@ contract SelfKeyAirdrop is Ownable {
     uint256 public airdropAmount = 10000000000000000000;
     uint256 public airdropCount = 0;
 
-    SelfKeyCrowdsale public crowdsale;
     SelfKeyToken public token;
 
     /**
@@ -33,10 +31,9 @@ contract SelfKeyAirdrop is Ownable {
 
     /**
      * @dev SelfKeyAirdrop contract constructor
-     * @param crowdsaleAddress - address of the SelfKey crowdsale contract
+     * @param tokenAddress - address of the SelfKey token contract
      */
-    function SelfKeyAirdrop (address crowdsaleAddress, address tokenAddress) public {
-        crowdsale = SelfKeyCrowdsale(crowdsaleAddress);
+    function SelfKeyAirdrop (address tokenAddress) public {
         token = SelfKeyToken(tokenAddress);
     }
 
@@ -80,7 +77,6 @@ contract SelfKeyAirdrop is Ownable {
      * @param _to - address to whom the airdrop is being done
      */
     function airdrop (address _to) public airdropperOnly {
-        require(crowdsale.kycVerified(_to));
         require(!airdropped[_to]);
 
         airdropCount = airdropCount + 1;

--- a/migrations/3_deploy_airdrop.js
+++ b/migrations/3_deploy_airdrop.js
@@ -1,8 +1,7 @@
 const SelfKeyAirdrop = artifacts.require('./SelfKeyAirdrop.sol')
 
 module.exports = deployer => {
-  const crowdsaleAddress = ''
   const tokenAddress = ''
 
-  deployer.deploy(SelfKeyAirdrop, crowdsaleAddress, tokenAddress)
+  deployer.deploy(SelfKeyAirdrop, tokenAddress)
 }

--- a/test/SelfKeyAirdrop_tests.js
+++ b/test/SelfKeyAirdrop_tests.js
@@ -27,7 +27,6 @@ contract('Airdrop contract', accounts => {
   before(async () => {
     // deploy crowdsale contract
     crowdsaleContract = await SelfKeyCrowdsale.new(start, end, goal)
-
     const tokenAddress = await crowdsaleContract.token.call()
     tokenContract = await SelfKeyToken.at(tokenAddress)
 
@@ -51,10 +50,7 @@ contract('Airdrop contract', accounts => {
     assert.isTrue(finalized)
 
     // deploy airdrop contract
-    airdropContract = await SelfKeyAirdrop.new(
-      crowdsaleContract.address,
-      tokenContract.address
-    )
+    airdropContract = await SelfKeyAirdrop.new(tokenContract.address)
     assert.isNotNull(airdropContract)
 
     // send tokens to the airdrop Contract
@@ -101,7 +97,7 @@ contract('Airdrop contract', accounts => {
     assert.isFalse(isAirdropper)
   })
 
-  it('allows airdropping to a verified address', async () => {
+  it('allows airdropping to an address', async () => {
     const initialBuyerBalance = await tokenContract.balanceOf.call(buyer)
     const initialAirdropBalance = await tokenContract.balanceOf.call(
       airdropContract.address
@@ -131,9 +127,6 @@ contract('Airdrop contract', accounts => {
     assert.isTrue(airdropped)
     await assertThrows(airdropContract.airdrop(buyer, { from: airdropper }))
   })
-
-  it('does not allow airdropping to a non-verified address', async () =>
-    assertThrows(airdropContract.airdrop(notVerified, { from: airdropper })))
 
   it('does not allow airdropping by a non-whitelisted address', async () =>
     assertThrows(airdropContract.airdrop(buyer2, { from: buyer })))

--- a/truffle.js
+++ b/truffle.js
@@ -52,8 +52,8 @@ module.exports = {
       network_id: 1,
       provider: engineMainnet,
       from: addresses[0],
-      gas: 5000000,
-      gasPrice: 75000000000
+      gas: 4500000,
+      gasPrice: 5000000000
     }
   },
   solc: {


### PR DESCRIPTION
Any address is now elegible for airdrop since the contract is trusting on the whitelisted airdropper to perform proper interaction with the IDWallet. Airdrop can now be requested from new addresses generated within the SelfKey IDWallet.